### PR TITLE
Add missing public typings

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1256,7 +1256,7 @@ declare namespace Ember {
     const K: Function;
     class LinkComponent extends Component {
       activeClass: string;
-      attributeBindings: any[] | String;
+      attributeBindings: any[] | string;
       classNameBindings: any[];
       currentWhen: any;
       rel: string | null;

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -296,7 +296,6 @@ interface Array<T> {
     cacheFor(keyName: string): any;
     decrementProperty(keyName: string, decrement?: number): number;
     endPropertyChanges(): any[];
-    expandProperties(pattern: string, callback: Function): any;
     get(keyName: string): any;
     getProperties(...args: string[]): {};
     getProperties(keys: string[]): {};
@@ -2489,6 +2488,7 @@ declare namespace Ember {
     // ReSharper disable once DuplicatingLocalDeclaration
     const empty: typeof deprecateFunc;
     function endPropertyChanges(): void;
+    function expandProperties(pattern: string, callback: Function): void;
     function finishChains(obj: any): void;
     function generateController(
         container: Container,

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -536,6 +536,12 @@ declare namespace Ember {
         registry: Registry;
     }
     /**
+    The `ApplicationInstance` encapsulates all of the stateful aspects of a
+    running `Application`.
+    **/
+    class ApplicationInstance extends EngineInstance {
+    }
+    /**
     This module implements Observer-friendly Array-like behavior. This mixin is picked up by the
     Array class as well as other controllers, etc. that want to appear to be arrays.
     **/
@@ -688,6 +694,11 @@ declare namespace Ember {
         removeObject(object: any): any;
         removeObjects(objects: Enumerable): MutableEnumberable;
     }
+    /**
+    AutoLocation will select the best location option based off browser support with the priority order: history, hash, none.
+    **/
+    class AutoLocation extends Object {
+    }
     const BOOTED: boolean;
     /**
     Connects the properties of two objects so that whenever the value of one property changes,
@@ -810,6 +821,16 @@ declare namespace Ember {
         destroy(): void;
         reset(): void;
     }
+    /**
+    The ContainerDebugAdapter helps the container and resolver interface
+    with tools that debug Ember such as the Ember Inspector for Chrome and Firefox.
+    **/
+    class ContainerDebugAdapter extends Object {
+      resolver: Resolver;
+      canCatalogEntriesByType(type: string): boolean;
+      catalogEntriesByType(type: string): Array;
+    }
+
     class Controller extends Object implements ControllerMixin {
         replaceRoute(name: string, ...args: any[]): void;
         transitionToRoute(name: string, ...args: any[]): void;
@@ -985,6 +1006,21 @@ declare namespace Ember {
         names: any[];
         vertices: {};
     }
+    /**
+    The DataAdapter helps a data persistence library interface with tools
+     that debug Ember such as the Ember Extension for Chrome and Firefox.
+    */
+    class DataAdapter extends Object {
+        acceptsModelName: any;
+        containerDebugAdapter: ContainerDebugAdapter;
+        getFilters(): Array;
+        watchModelTypes(typesAdded, typesUpdated): Function;
+        watchRecords(modelName, recordsAdded, recordsUpdated, recordsRemoved): Function
+    }
+    const Debug: {
+        registerDeprecationHandler(handler: Function): void;
+        registerWarnHandler(handler: Function): void;
+    }
     function DEFAULT_GETTER_FUNCTION(name: string): Function;
     /**
     The DefaultResolver defines the default lookup rules to resolve container lookups before consulting
@@ -1036,6 +1072,21 @@ declare namespace Ember {
         static isClass: boolean;
         static isMethod: boolean;
         unknownProperty(keyName: string, value: any): any[];
+    }
+    /**
+    The Engine class contains core functionality for both applications and engines.
+    **/
+    class Engine extends Namespace {
+      resolver: Resolver;
+      initializer(initializer: Object);
+      instanceInitializer (instanceInitializer : Object);
+    }
+    /**
+     The `EngineInstance` encapsulates all of the stateful aspects of a
+     running `Engine`.
+     **/
+    class EngineInstance extends Object {
+      unregister(fullName: string): void;
     }
     /**
     This mixin defines the common interface implemented by enumerable objects in Ember. Most of these
@@ -1203,6 +1254,17 @@ declare namespace Ember {
         unsubscribe(subscriber: any): void;
     }
     const K: Function;
+    class LinkComponent extends Component {
+      activeClass: string;
+      attributeBindings: Array | String;
+      classNameBindings: Array;
+      currentWhen: any;
+      rel: string | null;
+      replace: string | null;
+      tabindex: string | null;
+      target: string | null;
+      title: string | null;
+    }
     const LOG_BINDINGS: boolean;
     const LOG_STACKTRACE_ON_DEPRECATION: boolean;
     const LOG_VERSION: boolean;
@@ -1578,9 +1640,19 @@ declare namespace Ember {
         isEmpty(): boolean;
         toArray(): any[];
     }
+    /**
+    A low level mixin making ObjectProxy promise-aware.
+    */
+    class PromiseProxyMixin {
+      catch(callback: Function): Rsvp.Promise<any, any>;
+      finally(callback: Function): Rsvp.Promise<any, any>;
+      then(callback: Function): Rsvp.Promise<any, any>;
+    }
     class Registry {
         constructor(options: any);
         static set: typeof Ember.set;
+    }
+    class Resolver {
     }
 
     // FYI - RSVP source comes from https://github.com/tildeio/rsvp.js/blob/master/lib/rsvp/promise.js
@@ -2230,6 +2302,7 @@ declare namespace Ember {
         function decamelize(str: string): string;
         function fmt(...args: string[]): string;
         function htmlSafe(str: string): void; // TODO: @returns Handlebars.SafeStringStatic;
+        function isHTMLSafe(str: string): boolean;
         function loc(...args: string[]): string;
         function underscore(str: string): string;
         function w(str: string): string[];
@@ -2356,7 +2429,9 @@ declare namespace Ember {
         and(...args: string[]): ComputedProperty;
         any(...args: string[]): ComputedProperty;
         bool(dependentKey: string): ComputedProperty;
+        collect(dependentKey: string): ComputedProperty;
         defaultTo(defaultPath: string): ComputedProperty;
+        deprecatingAlias(dependentKey: string, options: any): ComputedProperty;
         empty(dependentKey: string): ComputedProperty;
         equal(dependentKey: string, value: any): ComputedProperty;
         filter(
@@ -2364,18 +2439,31 @@ declare namespace Ember {
             callback: (item: any, index?: number, array?: any[]) => boolean
         ): ComputedProperty;
         filterBy(dependentKey: string, propertyKey: string, value: any): ComputedProperty;
+        filterProperty(key: string, value?: string): Array;
         gt(dependentKey: string, value: number): ComputedProperty;
         gte(dependentKey: string, value: number): ComputedProperty;
+        intersect(propertyKey: string): ComputedProperty;
         lt(dependentKey: string, value: number): ComputedProperty;
         lte(dependentKey: string, value: number): ComputedProperty;
         map(dependentKey: string, callback: <T>(item: any, index: number) => T): ComputedProperty;
+        mapBy(dependentKey: string, propertyKey: string): ComputedProperty;
+        mapProperty(key: string): Array;
         match(dependentKey: string, regexp: RegExp): ComputedProperty;
+        max(dependentKey: string): ComputedProperty;
+        min(dependentKey: string): ComputedProperty;
         none(dependentKey: string): ComputedProperty;
         not(dependentKey: string): ComputedProperty;
         notEmpty(dependentKey: string): ComputedProperty;
         oneWay(dependentKey: string): ComputedProperty;
         or(...args: string[]): ComputedProperty;
         readOnly(dependentString: string): ComputedProperty;
+        reads(dependentKey: string): ComputedProperty;
+        setDiff(setAProperty: string, setBProperty: string): ComputedProperty;
+        sort(itemsKey: string, sortDefinition: string | Function): ComputedProperty;
+        sum(dependentKey: string): ComputedProperty;
+        union(propertyKey: string): ComputedProperty;
+        uniq(propertyKey: string): ComputedProperty;
+        uniqBy(dependentKey: string, propertyKey: string): ComputedProperty;
     };
     // ReSharper restore DuplicatingLocalDeclaration
     function controllerFor(
@@ -2408,6 +2496,7 @@ declare namespace Ember {
     ): Controller;
     function generateGuid(obj: any, prefix?: string): string;
     function get(obj: any, keyName: string): any;
+    function getEngineParent(engine: EngineInstance): EngineInstance;
     function getProperties(obj: any, ...args: string[]): object;
     function getProperties(obj: any, keys: string[]): object;
     /**
@@ -2448,6 +2537,7 @@ declare namespace Ember {
     const none: typeof deprecateFunc;
     function observer(...args: any[]): Function;
     function observersFor(obj: any, path: string): any[];
+    function on(eventNames: string, func: Function): Function;
     function onLoad(name: string, callback: Function): void;
     const onError: Error;
     function onerror(error: any): void;
@@ -2469,6 +2559,7 @@ declare namespace Ember {
     ): void;
     function removeObserver(obj: any, path: string, target: any, method: Function): any;
     function required(): Descriptor;
+    function reset(): void;
     function rewatch(obj: any): void;
 
     type RunMethod<T> = (...args: any[]) => T;
@@ -2514,6 +2605,7 @@ declare namespace Ember {
     **/
     const trySetPath: typeof deprecateFunc;
     function typeOf(item: any): string;
+    function unsubscribe(subscriber: any): void;
     function unwatch(obj: any, keyPath: string): void;
     function unwatchKey(obj: any, keyName: string): void;
     function unwatchPath(obj: any, keyPath: string): void;

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Ember.js 2.7
+// Type definitions for Ember.js 2.8
 // Project: http://emberjs.com/
 // Definitions by: Jed Mao <https://github.com/jedmao>
 //                 bttf <https://github.com/bttf>

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for Ember.js 2.7
+// Type definitions for Ember.js 2.7
 // Project: http://emberjs.com/
 // Definitions by: Jed Mao <https://github.com/jedmao>
 //                 bttf <https://github.com/bttf>

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -296,6 +296,7 @@ interface Array<T> {
     cacheFor(keyName: string): any;
     decrementProperty(keyName: string, decrement?: number): number;
     endPropertyChanges(): any[];
+    expandProperties(pattern: string, callback: Function): any;
     get(keyName: string): any;
     getProperties(...args: string[]): {};
     getProperties(keys: string[]): {};

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -828,7 +828,7 @@ declare namespace Ember {
     class ContainerDebugAdapter extends Object {
       resolver: Resolver;
       canCatalogEntriesByType(type: string): boolean;
-      catalogEntriesByType(type: string): Array;
+      catalogEntriesByType(type: string): any[];
     }
 
     class Controller extends Object implements ControllerMixin {
@@ -1013,14 +1013,14 @@ declare namespace Ember {
     class DataAdapter extends Object {
         acceptsModelName: any;
         containerDebugAdapter: ContainerDebugAdapter;
-        getFilters(): Array;
-        watchModelTypes(typesAdded, typesUpdated): Function;
-        watchRecords(modelName, recordsAdded, recordsUpdated, recordsRemoved): Function
+        getFilters(): any[];
+        watchModelTypes(typesAdded: any, typesUpdated: any): Function;
+        watchRecords(modelName: any, recordsAdded: any, recordsUpdated: any, recordsRemoved: any): Function;
     }
     const Debug: {
         registerDeprecationHandler(handler: Function): void;
         registerWarnHandler(handler: Function): void;
-    }
+    };
     function DEFAULT_GETTER_FUNCTION(name: string): Function;
     /**
     The DefaultResolver defines the default lookup rules to resolve container lookups before consulting
@@ -1078,8 +1078,8 @@ declare namespace Ember {
     **/
     class Engine extends Namespace {
       resolver: Resolver;
-      initializer(initializer: Object);
-      instanceInitializer (instanceInitializer : Object);
+      initializer(initializer: Object): any;
+      instanceInitializer(instanceInitializer: Object): any;
     }
     /**
      The `EngineInstance` encapsulates all of the stateful aspects of a
@@ -1256,8 +1256,8 @@ declare namespace Ember {
     const K: Function;
     class LinkComponent extends Component {
       activeClass: string;
-      attributeBindings: Array | String;
-      classNameBindings: Array;
+      attributeBindings: any[] | String;
+      classNameBindings: any[];
       currentWhen: any;
       rel: string | null;
       replace: string | null;
@@ -2447,7 +2447,7 @@ declare namespace Ember {
             callback: (item: any, index?: number, array?: any[]) => boolean
         ): ComputedProperty;
         filterBy(dependentKey: string, propertyKey: string, value?: any): ComputedProperty;
-        filterProperty(key: string, value?: string): Array;
+        filterProperty(key: string, value?: string): any[];
         gt(dependentKey: string, value: number): ComputedProperty;
         gte(dependentKey: string, value: number): ComputedProperty;
         intersect(...args: string[]): ComputedProperty;
@@ -2455,7 +2455,7 @@ declare namespace Ember {
         lte(dependentKey: string, value: number): ComputedProperty;
         map(dependentKey: string, callback: <T>(item: any, index: number) => T): ComputedProperty;
         mapBy(dependentKey: string, propertyKey: string): ComputedProperty;
-        mapProperty(key: string): Array;
+        mapProperty(key: string): any[];
         match(dependentKey: string, regexp: RegExp): ComputedProperty;
         max(dependentKey: string): ComputedProperty;
         min(dependentKey: string): ComputedProperty;


### PR DESCRIPTION
This adds all missing public exports needed for new modules api (rfc 176) imports. 
Warning: contains duplicates of Ember.computed typings done also in https://github.com/typed-ember/ember-typings/pull/3
some are better in that PR, some might be better here, so they might need to be checked on case by case basis.
Along with https://gist.github.com/vlascik/bd1843403610f98c9550bb635a6501d9 this should be enough to get the new imports working.