### PR TITLE
ember-decorators: computed is a named export

### DIFF
--- a/types/ember-decorators/ember-decorators-tests.ts
+++ b/types/ember-decorators/ember-decorators-tests.ts
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import computed from 'ember-decorators/object';
+import { computed } from 'ember-decorators/object';
 import { alias, and } from 'ember-decorators/object/computed';
 
 /** Static assertion that `value` has type `T` */

--- a/types/ember-decorators/index.d.ts
+++ b/types/ember-decorators/index.d.ts
@@ -10,5 +10,5 @@ declare module 'ember-decorators/object/computed' {
 }
 
 declare module 'ember-decorators/object' {
-    export default function(...keys: string[]): PropertyDecorator;
+    export function computed(...keys: string[]): PropertyDecorator;
 }


### PR DESCRIPTION
it was previously defined as the default export