### PR TITLE
update @computed return type

### DIFF
--- a/types/ember-decorators/index.d.ts
+++ b/types/ember-decorators/index.d.ts
@@ -10,5 +10,5 @@ declare module 'ember-decorators/object/computed' {
 }
 
 declare module 'ember-decorators/object' {
-    export function computed(...keys: string[]): PropertyDecorator;
+    export function computed(...keys: string[]): MethodDecorator;
 }


### PR DESCRIPTION
Shouldn't we use MethodDecorator here instead of PropertyDecorator?

I wonder why typescript does not shout at us with the current declaration of @computed ...