### PR TITLE
Add typings for ember-qunit

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   },
   "scripts": {
     "test": "node node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed --all",
+    "generate": "node node_modules/dts-gen/bin/lib/run.js --dt",
     "lint": "dtslint types"
   },
   "devDependencies": {
+    "dts-gen": "^0.5.6",
     "dtslint": "Microsoft/dtslint#production",
     "types-publisher": "Microsoft/types-publisher#production"
   },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@types/handlebars": "^4.0.35",
     "@types/jquery": "^3.2.11",
+    "@types/qunit": "^2.0.31",
     "@types/rsvp": "^3.3.1",
     "jslint": "^0.10.3"
   }

--- a/types/ember-cli-qunit/ember-cli-qunit-tests.ts
+++ b/types/ember-cli-qunit/ember-cli-qunit-tests.ts
@@ -1,0 +1,3 @@
+import { start } from 'ember-cli-qunit';
+
+start();

--- a/types/ember-cli-qunit/index.d.ts
+++ b/types/ember-cli-qunit/index.d.ts
@@ -1,0 +1,6 @@
+// Type definitions for ember-cli-qunit 4.0
+// Project: https://github.com/ember-cli/ember-cli-qunit
+// Definitions by: Derek Wickern <https://github.com/dwickern>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function start(): void;

--- a/types/ember-cli-qunit/tsconfig.json
+++ b/types/ember-cli-qunit/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ember-cli-qunit-tests.ts"
+    ]
+}

--- a/types/ember-cli-qunit/tslint.json
+++ b/types/ember-cli-qunit/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/ember-qunit/ember-qunit-tests.ts
+++ b/types/ember-qunit/ember-qunit-tests.ts
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-// import hbs from 'htmlbars-inline-precompile';
+import hbs from 'htmlbars-inline-precompile';
 import { test, skip, moduleFor, moduleForModel, moduleForComponent, setResolver } from 'ember-qunit';
 
 moduleForComponent('x-foo', {
@@ -49,9 +49,9 @@ test('it renders', function(assert) {
     });
 
     // render the component
-    // this.render(hbs`
-    //     {{ x-foo value=value action="result" }}
-    // `);
+    this.render(hbs`
+        {{ x-foo value=value action="result" }}
+    `);
 
     assert.equal(this.$('div>.value').text(), 'cat', 'The component shows the correct value');
 

--- a/types/ember-qunit/ember-qunit-tests.ts
+++ b/types/ember-qunit/ember-qunit-tests.ts
@@ -24,6 +24,11 @@ moduleFor('component:x-foo', 'TestModule callbacks', {
     },
 
     beforeEach(assert) {
+        this.registry.register('helper:i18n', {});
+        this.register('service:i18n', {});
+        this.inject.service('i18n');
+        this.inject.service('i18n', { as: 'i18n' });
+        this.factory('object:user').create();
         assert.ok(true);
     },
 
@@ -46,24 +51,42 @@ test('it renders', function(assert) {
     this.set('value', 'cat');
     this.on('action', function(result) {
         assert.equal(result, 'bar', 'The correct result was returned');
+        assert.equal(this.get('value'), 'cat');
     });
 
     // render the component
     this.render(hbs`
         {{ x-foo value=value action="result" }}
     `);
+    this.render('{{ x-foo value=value action="result" }}');
+    this.render([
+        '{{ x-foo value=value action="result" }}'
+    ]);
 
     assert.equal(this.$('div>.value').text(), 'cat', 'The component shows the correct value');
 
     this.$('button').click();
 });
 
-// run a test
 test('it renders', function(assert) {
     assert.expect(1);
 
     // creates the component instance
     const subject = this.subject();
+
+    const subject2 = this.subject({
+        item: 42
+    });
+
+    const { inputFormat } = this.setProperties({
+        inputFormat: 'M/D/YY',
+        outputFormat: 'MMMM D, YYYY',
+        date: '5/3/10'
+    });
+
+    const { inputFormat: if2, outputFormat } = this.getProperties('inputFormat', 'outputFormat');
+
+    const inputFormat2 = this.get('inputFormat');
 
     // render the component on the page
     this.render();

--- a/types/ember-qunit/ember-qunit-tests.ts
+++ b/types/ember-qunit/ember-qunit-tests.ts
@@ -1,0 +1,84 @@
+import Ember from 'ember';
+// import hbs from 'htmlbars-inline-precompile';
+import { test, skip, moduleFor, moduleForModel, moduleForComponent, setResolver } from 'ember-qunit';
+
+moduleForComponent('x-foo', {
+    integration: true
+});
+
+moduleForComponent('x-foo', {
+    unit: true,
+    needs: ['helper:pluralize-string']
+});
+
+moduleForModel('user', {
+    needs: ['model:child']
+});
+
+moduleFor('controller:home');
+
+moduleFor('component:x-foo', 'Some description');
+
+moduleFor('component:x-foo', 'TestModule callbacks', {
+    beforeSetup() {
+    },
+
+    beforeEach(assert) {
+        assert.ok(true);
+    },
+
+    afterEach(assert) {
+        assert.ok(true);
+    },
+
+    afterTeardown(assert) {
+        assert.ok(true);
+    }
+});
+
+// if you don't have a custom resolver, do it like this:
+setResolver(Ember.DefaultResolver.create());
+
+test('it renders', function(assert) {
+    assert.expect(2);
+
+    // setup the outer context
+    this.set('value', 'cat');
+    this.on('action', function(result) {
+        assert.equal(result, 'bar', 'The correct result was returned');
+    });
+
+    // render the component
+    // this.render(hbs`
+    //     {{ x-foo value=value action="result" }}
+    // `);
+
+    assert.equal(this.$('div>.value').text(), 'cat', 'The component shows the correct value');
+
+    this.$('button').click();
+});
+
+// run a test
+test('it renders', function(assert) {
+    assert.expect(1);
+
+    // creates the component instance
+    const subject = this.subject();
+
+    // render the component on the page
+    this.render();
+    assert.equal(this.$('.foo').text(), 'bar');
+});
+
+test('It can calculate the result', function(assert) {
+    assert.expect(1);
+
+    const subject = this.subject();
+
+    subject.set('value', 'foo');
+    assert.equal(subject.get('result'), 'bar');
+});
+
+skip('disabled test');
+
+skip('disabled test', function(assert) { });

--- a/types/ember-qunit/index.d.ts
+++ b/types/ember-qunit/index.d.ts
@@ -1,0 +1,134 @@
+// Type definitions for ember-qunit 2.2
+// Project: https://github.com/emberjs/ember-qunit#readme
+// Definitions by: Derek Wickern <https://github.com/dwickern>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+/// <reference types="qunit" />
+/// <reference types="jquery" />
+
+interface TestContext {
+    set(key: string, value: any): void;
+    on(event: string, callback: (...args: any[]) => any): void;
+    $: JQueryStatic;
+    subject(): any;
+    render(template?: any): void;
+}
+
+interface ModuleCallbacks extends Hooks {
+    integration?: boolean;
+    unit?: boolean;
+    needs?: string[];
+
+    beforeSetup?(assert: Assert): void;
+    setup?(assert: Assert): void;
+    teardown?(assert: Assert): void;
+    afterTeardown?(assert: Assert): void;
+}
+
+declare module 'ember-qunit' {
+    import Ember from 'ember';
+
+    /**
+     *
+     * @param {string} fullName The full name of the unit, ie controller:application, route:index.
+     * @param {string} description The description of the module
+     * @param {ModuleCallbacks} callbacks
+     */
+    export function moduleFor(fullName: string, description: string, callbacks?: ModuleCallbacks): void;
+    export function moduleFor(fullName: string, callbacks?: ModuleCallbacks): void;
+
+    /**
+     *
+     * @param {string} fullName the short name of the component that you'd use in a template, ie x-foo, ic-tabs, etc.
+     * @param {string} description The description of the module
+     * @param {ModuleCallbacks} callbacks
+     */
+    export function moduleForComponent(fullName: string, description: string, callbacks?: ModuleCallbacks): void;
+    export function moduleForComponent(fullName: string, callbacks?: ModuleCallbacks): void;
+
+    /**
+     *
+     * @param {string} fullName the short name of the model you'd use in store operations ie user, assignmentGroup, etc.
+     * @param {string} description The description of the module
+     * @param {ModuleCallbacks} callbacks
+     */
+    export function moduleForModel(fullName: string, description: string, callbacks?: ModuleCallbacks): void;
+    export function moduleForModel(fullName: string, callbacks?: ModuleCallbacks): void;
+
+    /**
+     * Sets a Resolver globally which will be used to look up objects from each test's container.
+     */
+    export function setResolver(resolver: Ember.Resolver): void;
+
+    export class QUnitAdapter extends Ember.Test.Adapter {}
+
+    export { module, test, skip, only, todo } from 'qunit';
+}
+
+declare module 'qunit' {
+    export const module: typeof QUnit.module;
+
+    /**
+     * Add a test to run.
+     *
+     * Add a test to run using `QUnit.test()`.
+     *
+     * The `assert` argument to the callback contains all of QUnit's assertion
+     * methods. Use this argument to call your test assertions.
+     *
+     * `QUnit.test()` can automatically handle the asynchronous resolution of a
+     * Promise on your behalf if you return a thenable Promise as the result of
+     * your callback function.
+     *
+     * @param {string} name Title of unit being tested
+     * @param callback Function to close over assertions
+     */
+    export function test(name: string, callback: (this: TestContext, assert: Assert) => void): void;
+
+    /**
+     * Adds a test to exclusively run, preventing all other tests from running.
+     *
+     * Use this method to focus your test suite on a specific test. QUnit.only
+     * will cause any other tests in your suite to be ignored.
+     *
+     * Note, that if more than one QUnit.only is present only the first instance
+     * will run.
+     *
+     * This is an alternative to filtering tests to run in the HTML reporter. It
+     * is especially useful when you use a console reporter or in a codebase
+     * with a large set of long running tests.
+     *
+     * @param {string} name Title of unit being tested
+     * @param callback Function to close over assertions
+     */
+    export function only(name: string, callback: (this: TestContext, assert: Assert) => void): void;
+
+    /**
+     * Use this method to test a unit of code which is still under development (in a “todo” state).
+     * The test will pass as long as one failing assertion is present.
+     *
+     * If all assertions pass, then the test will fail signaling that `QUnit.todo` should
+     * be replaced by `QUnit.test`.
+     *
+     * @param {string} name Title of unit being tested
+     * @param callback Function to close over assertions
+     */
+    export function todo(name: string, callback: (this: TestContext, assert: Assert) => void): void;
+
+    /**
+     * Adds a test like object to be skipped.
+     *
+     * Use this method to replace QUnit.test() instead of commenting out entire
+     * tests.
+     *
+     * This test's prototype will be listed on the suite as a skipped test,
+     * ignoring the callback argument and the respective global and module's
+     * hooks.
+     *
+     * @param {string} Title of unit being tested
+     */
+    export const skip: typeof QUnit.skip;
+
+    export default QUnit;
+}

--- a/types/ember-qunit/index.d.ts
+++ b/types/ember-qunit/index.d.ts
@@ -4,11 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-/// <reference types="qunit" />
 /// <reference types="jquery" />
 
 declare module 'ember-qunit' {
     import Ember from 'ember';
+    import { TestContext } from 'qunit';
 
     interface ModuleCallbacks extends Hooks {
         integration?: boolean;
@@ -27,8 +27,8 @@ declare module 'ember-qunit' {
      * @param {string} description The description of the module
      * @param {ModuleCallbacks} callbacks
      */
-    export function moduleFor(fullName: string, description: string, callbacks?: ModuleCallbacks): void;
-    export function moduleFor(fullName: string, callbacks?: ModuleCallbacks): void;
+    export function moduleFor(fullName: string, description: string, callbacks?: ModuleCallbacks & ThisType<TestContext>): void;
+    export function moduleFor(fullName: string, callbacks?: ModuleCallbacks & ThisType<TestContext>): void;
 
     /**
      *
@@ -36,8 +36,8 @@ declare module 'ember-qunit' {
      * @param {string} description The description of the module
      * @param {ModuleCallbacks} callbacks
      */
-    export function moduleForComponent(fullName: string, description: string, callbacks?: ModuleCallbacks): void;
-    export function moduleForComponent(fullName: string, callbacks?: ModuleCallbacks): void;
+    export function moduleForComponent(fullName: string, description: string, callbacks?: ModuleCallbacks & ThisType<TestContext>): void;
+    export function moduleForComponent(fullName: string, callbacks?: ModuleCallbacks & ThisType<TestContext>): void;
 
     /**
      *
@@ -45,8 +45,8 @@ declare module 'ember-qunit' {
      * @param {string} description The description of the module
      * @param {ModuleCallbacks} callbacks
      */
-    export function moduleForModel(fullName: string, description: string, callbacks?: ModuleCallbacks): void;
-    export function moduleForModel(fullName: string, callbacks?: ModuleCallbacks): void;
+    export function moduleForModel(fullName: string, description: string, callbacks?: ModuleCallbacks & ThisType<TestContext>): void;
+    export function moduleForModel(fullName: string, callbacks?: ModuleCallbacks & ThisType<TestContext>): void;
 
     /**
      * Sets a Resolver globally which will be used to look up objects from each test's container.
@@ -59,14 +59,29 @@ declare module 'ember-qunit' {
 }
 
 declare module 'qunit' {
+    import Ember from 'ember';
     import { TemplateFactory } from 'htmlbars-inline-precompile';
 
-    interface TestContext {
-        set(key: string, value: any): void;
-        on(event: string, callback: (...args: any[]) => any): void;
+    export interface TestContext {
+        get(key: string): any;
+        getProperties<K extends string>(...keys: K[]): Pick<any, K>;
+        set<V>(key: string, value: V): V;
+        setProperties<P extends { [key: string]: any }>(hash: P): P;
+        on(actionName: string, handler: (this: TestContext, ...args: any[]) => any): void;
+        send(actionName: string): void;
         $: JQueryStatic;
-        subject(): any;
-        render(template?: TemplateFactory): void;
+        subject(options?: {}): any;
+        render(template?: string | string[] | TemplateFactory): void;
+        clearRender(): void;
+        registry: Ember.Registry;
+        container: Ember.Container;
+        dispatcher: Ember.EventDispatcher;
+        register(fullName: string, factory: any): void;
+        factory(fullName: string): any;
+        inject: {
+            controller(name: string, options?: { as: string }): any;
+            service(name: string, options?: { as: string }): any;
+        };
     }
 
     export const module: typeof QUnit.module;

--- a/types/ember-qunit/index.d.ts
+++ b/types/ember-qunit/index.d.ts
@@ -7,27 +7,19 @@
 /// <reference types="qunit" />
 /// <reference types="jquery" />
 
-interface TestContext {
-    set(key: string, value: any): void;
-    on(event: string, callback: (...args: any[]) => any): void;
-    $: JQueryStatic;
-    subject(): any;
-    render(template?: any): void;
-}
-
-interface ModuleCallbacks extends Hooks {
-    integration?: boolean;
-    unit?: boolean;
-    needs?: string[];
-
-    beforeSetup?(assert: Assert): void;
-    setup?(assert: Assert): void;
-    teardown?(assert: Assert): void;
-    afterTeardown?(assert: Assert): void;
-}
-
 declare module 'ember-qunit' {
     import Ember from 'ember';
+
+    interface ModuleCallbacks extends Hooks {
+        integration?: boolean;
+        unit?: boolean;
+        needs?: string[];
+
+        beforeSetup?(assert: Assert): void;
+        setup?(assert: Assert): void;
+        teardown?(assert: Assert): void;
+        afterTeardown?(assert: Assert): void;
+    }
 
     /**
      *
@@ -67,6 +59,16 @@ declare module 'ember-qunit' {
 }
 
 declare module 'qunit' {
+    import { TemplateFactory } from 'htmlbars-inline-precompile';
+
+    interface TestContext {
+        set(key: string, value: any): void;
+        on(event: string, callback: (...args: any[]) => any): void;
+        $: JQueryStatic;
+        subject(): any;
+        render(template?: TemplateFactory): void;
+    }
+
     export const module: typeof QUnit.module;
 
     /**

--- a/types/ember-qunit/tsconfig.json
+++ b/types/ember-qunit/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ember-qunit-tests.ts"
+    ]
+}

--- a/types/ember-qunit/tslint.json
+++ b/types/ember-qunit/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "only-arrow-functions": false,
+        "strict-export-declare-modifiers": false
+    }
+}

--- a/types/ember-qunit/tslint.json
+++ b/types/ember-qunit/tslint.json
@@ -2,6 +2,7 @@
     "extends": "dtslint/dt.json",
     "rules": {
         "only-arrow-functions": false,
-        "strict-export-declare-modifiers": false
+        "strict-export-declare-modifiers": false,
+        "no-duplicate-imports": false
     }
 }

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1010,6 +1010,8 @@ namespace Ember {
     class Registry {
         constructor(options: any);
         static set: typeof Ember.set;
+        register(fullName: string, factory: any): void;
+        unregister(fullName: string): void;
     }
     class Resolver extends Ember.Object {
     }

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -708,7 +708,7 @@ namespace Ember {
     other names are looked up on the application after converting the name.
     For example, controller:post looks up App.PostController by default.
     **/
-    class DefaultResolver {
+    class DefaultResolver extends Resolver {
         resolve(fullName: string): {};
         namespace: Application;
     }
@@ -1011,7 +1011,7 @@ namespace Ember {
         constructor(options: any);
         static set: typeof Ember.set;
     }
-    class Resolver {
+    class Resolver extends Ember.Object {
     }
 
     // FYI - RSVP source comes from https://github.com/tildeio/rsvp.js/blob/master/lib/rsvp/promise.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -207,6 +207,10 @@ builtins@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
 
+camelcase@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
+
 camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
@@ -332,6 +336,18 @@ diff@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
 
+dts-dom@latest:
+  version "0.1.20"
+  resolved "https://registry.yarnpkg.com/dts-dom/-/dts-dom-0.1.20.tgz#1f9d1fd39d3f460ffa3a7b5f716fe41a8371d584"
+
+dts-gen@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/dts-gen/-/dts-gen-0.5.6.tgz#558aa67577f3bdfa8d07d1b0ec14a588ea47d8f6"
+  dependencies:
+    dts-dom latest
+    typescript "^2.2.0"
+    yargs "^4.8.1"
+
 dtslint@Microsoft/dtslint#production:
   version "0.1.2"
   resolved "https://codeload.github.com/Microsoft/dtslint/tar.gz/0d6b9c1e63a3f70a75fd14d2b6e2f53cfd9bcd3d"
@@ -407,6 +423,13 @@ extend@~3.0.0:
 extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+
+find-up@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
+  dependencies:
+    path-exists "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 find-up@^2.0.0:
   version "2.1.0"
@@ -653,6 +676,10 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
+is-utf8@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -758,6 +785,16 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+load-json-file@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    strip-bom "^2.0.0"
+
 load-json-file@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
@@ -773,6 +810,10 @@ locate-path@^2.0.0:
   dependencies:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
+
+lodash.assign@^4.0.3, lodash.assign@^4.0.6:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
 lodash@^4.14.0:
   version "4.17.4"
@@ -967,6 +1008,12 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
+os-locale@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+  dependencies:
+    lcid "^1.0.0"
+
 os-locale@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
@@ -1010,6 +1057,12 @@ parsimmon@^1.2.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/parsimmon/-/parsimmon-1.6.2.tgz#28fbe6b8caa38ab89f52b77f8c7743563c7d9aff"
 
+path-exists@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
+  dependencies:
+    pinkie-promise "^2.0.0"
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -1025,6 +1078,14 @@ path-key@^2.0.0:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-type@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
+  dependencies:
+    graceful-fs "^4.1.2"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -1070,12 +1131,27 @@ qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
+read-pkg-up@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
+  dependencies:
+    find-up "^1.0.0"
+    read-pkg "^1.0.0"
+
 read-pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
   dependencies:
     find-up "^2.0.0"
     read-pkg "^2.0.0"
+
+read-pkg@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
+  dependencies:
+    load-json-file "^1.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^1.0.0"
 
 read-pkg@^2.0.0:
   version "2.0.0"
@@ -1326,6 +1402,12 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-bom@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
+  dependencies:
+    is-utf8 "^0.2.0"
+
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -1443,7 +1525,7 @@ types-publisher@Microsoft/types-publisher#production:
     typescript "^2.4.0"
     yargs "^8.0.2"
 
-typescript@^2.4.0:
+typescript@^2.2.0, typescript@^2.4.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.1.tgz#ce7cc93ada3de19475cc9d17e3adea7aee1832aa"
 
@@ -1494,6 +1576,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+which-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
@@ -1509,6 +1595,10 @@ wide-align@^1.1.0:
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
   dependencies:
     string-width "^1.0.2"
+
+window-size@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
@@ -1551,11 +1641,37 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
+yargs-parser@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-2.4.1.tgz#85568de3cf150ff49fa51825f03a8c880ddcc5c4"
+  dependencies:
+    camelcase "^3.0.0"
+    lodash.assign "^4.0.6"
+
 yargs-parser@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
     camelcase "^4.1.0"
+
+yargs@^4.8.1:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-4.8.1.tgz#c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0"
+  dependencies:
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    lodash.assign "^4.0.3"
+    os-locale "^1.4.0"
+    read-pkg-up "^1.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^1.0.1"
+    which-module "^1.0.0"
+    window-size "^0.2.0"
+    y18n "^3.2.1"
+    yargs-parser "^2.4.1"
 
 yargs@^8.0.2:
   version "8.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,10 @@
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@types/parsimmon/-/parsimmon-1.3.0.tgz#0509b11d85e7d10f83141e5d4490ba8ad5e5cbec"
 
+"@types/qunit@^2.0.31":
+  version "2.0.31"
+  resolved "https://registry.yarnpkg.com/@types/qunit/-/qunit-2.0.31.tgz#a53e2cf635262c8bf46a71a137d8c7970dde9562"
+
 "@types/rsvp@^3.3.1":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@types/rsvp/-/rsvp-3.3.2.tgz#320020a9a5a6a71e99d852fa88df43bd9f878278"


### PR DESCRIPTION
Fixes #13

- [x] Needs typings for `htmlbars-inline-precompile` in order to properly type the signature for ```this.render(hbs`...`)```

The typings for ember-cli-qunit are so trivial, it seems silly to even include them.