### PR TITLE
[WIP] Flesh out Component/Route/Controller typings

### DIFF
--- a/types/ember-inflector/ember-inflector-tests.ts
+++ b/types/ember-inflector/ember-inflector-tests.ts
@@ -11,12 +11,12 @@ Ember.String.singularize("tacos"); // taco
 Ember.String.pluralize("taco"); // tacos
 
 // or if not using Ember CLI/ES6
-Inflector.inflector.pluralize("taco"); // tacos
+Ember.Inflector.inflector.pluralize("taco"); // tacos
 
 const inflector = Inflector.inflector;
 const inflector2 = new Inflector();
-const inflector3 = new Inflector();
-const inflector4 = new Inflector(Inflector.defaultRules);
+const inflector3 = new Ember.Inflector();
+const inflector4 = new Ember.Inflector(Ember.Inflector.defaultRules);
 
 const customRules = {
     plurals:  [
@@ -31,7 +31,7 @@ const customRules = {
     uncountable: [ 'fish' ]
 };
 
-const inflector5 = new Inflector(customRules);
+const inflector5 = new Ember.Inflector(customRules);
 
 inflector.irregular('formula', 'formulae');
 inflector.uncountable('advice');

--- a/types/ember-inflector/ember-inflector-tests.ts
+++ b/types/ember-inflector/ember-inflector-tests.ts
@@ -11,12 +11,12 @@ Ember.String.singularize("tacos"); // taco
 Ember.String.pluralize("taco"); // tacos
 
 // or if not using Ember CLI/ES6
-Ember.Inflector.inflector.pluralize("taco"); // tacos
+Inflector.inflector.pluralize("taco"); // tacos
 
 const inflector = Inflector.inflector;
 const inflector2 = new Inflector();
-const inflector3 = new Ember.Inflector();
-const inflector4 = new Ember.Inflector(Ember.Inflector.defaultRules);
+const inflector3 = new Inflector();
+const inflector4 = new Inflector(Inflector.defaultRules);
 
 const customRules = {
     plurals:  [
@@ -31,7 +31,7 @@ const customRules = {
     uncountable: [ 'fish' ]
 };
 
-const inflector5 = new Ember.Inflector(customRules);
+const inflector5 = new Inflector(customRules);
 
 inflector.irregular('formula', 'formulae');
 inflector.uncountable('advice');

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -239,7 +239,7 @@ interface ControllerMixin extends ActionHandler {
 }
 const ControllerMixin: Ember.Mixin<ControllerMixin>;
 
-namespace Ember {
+export namespace Ember {
     /**
     Alias for jQuery.
     **/
@@ -1561,7 +1561,7 @@ namespace Ember {
         Beside that, it is identical to `transitionTo` in all other respects. See
         'transitionTo' for additional information regarding multiple models.
         */
-      replaceWith(name: string, ...modelsAndOrOptions: any[]): Transition;
+      replaceWith(name: string, ...args: any[]): Transition;
 
       /**
         A hook you can use to reset controller values either when the model

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -234,7 +234,7 @@ interface ControllerMixin extends ActionHandler {
     replaceRoute(name: string, ...args: any[]): void;
     transitionToRoute(name: string, ...args: any[]): void;
     model: any;
-    queryParams: string[] | { [key: string]: { type: string } }[];
+    queryParams: string[] | Array<{ [key: string]: { type: string } }>;
     target: Object;
 }
 const ControllerMixin: Ember.Mixin<ControllerMixin>;

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -536,7 +536,7 @@ export namespace Ember {
         /**
         Enables components to take a list of parameters as arguments.
         **/
-        positionalParams: string[] | string;
+        static positionalParams: string[] | string;
         // events
         /**
         Called when the attributes passed into the component have been updated. Called both during the

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -118,6 +118,12 @@ interface RenderOptions {
     view?: string;
 }
 
+interface RouteQueryParam {
+    refreshModel?: boolean;
+    replace?: boolean;
+    as?: string;
+}
+
 interface ViewMixin {
     // methods
     $: JQueryStatic;
@@ -1426,36 +1432,18 @@ namespace Ember {
       the [routing guide](http://emberjs.com/guides/routing/) for documentation.
     */
     class Route extends Object.extend(ActionHandler, Evented) {
-        /**
-        This hook is executed when the router enters the route. It is not executed
-        when the model for the route changes.
-        @method activate
-        */
-        activate: Function;
-
-        /**
+      //methods
+      /**
         This hook is called after this route's model has resolved.
         It follows identical async/promise semantics to `beforeModel`
         but is provided the route's resolved model in addition to
         the `transition`, and is therefore suited to performing
         logic that can only take place after the model has already
         resolved.
-
-        Refer to documentation for `beforeModel` for a description
-        of transition-pausing semantics when a promise is returned
-        from this hook.
-        @method afterModel
-        @param {Object} resolvedModel the value returned from `model`,
-            or its resolved value if it was a promise
-        @param {Transition} transition
-        @return {Promise} if the value returned from this hook is
-            a promise, the transition will pause until the transition
-            resolves. Otherwise, non-promise return values are not
-            utilized in any way.
         */
         afterModel(resolvedModel: any, transition: Transition): Rsvp.Promise<any>;
 
-        /**
+      /**
         This hook is the first of the route entry validation hooks
         called when an attempt is made to transition into a route
         or one of its children. It is called before `model` and
@@ -1474,100 +1462,26 @@ namespace Ember {
         transition until the promise resolves (or rejects). This could
         be useful, for instance, for retrieving async code from
         the server that is required to enter a route.
-
-        @method beforeModel
-        @param {Transition} transition
-        @return {Promise} if the value returned from this hook is
-            a promise, the transition will pause until the transition
-            resolves. Otherwise, non-promise return values are not
-            utilized in any way.
         */
         beforeModel(transition: Transition): Rsvp.Promise<any>;
 
-        /**
-        The controller associated with this route.
-
-        @property controller
-        @type Ember.Controller
-        @since 1.6.0
-        */
-        controller: Controller;
-
-        /**
+      /**
         Returns the controller for a particular route or name.
         The controller instance must already have been created, either through entering the
         associated route or using `generateController`.
-
-        @method controllerFor
-        @param {String} name the name of the route or controller
-        @return {Ember.Controller}
         */
-        controllerFor(name: string): Controller;
+      controllerFor(name: string): Controller;
 
-        /**
-        The name of the controller to associate with this route.
-        By default, Ember will lookup a route's controller that matches the name
-        of the route (i.e. `App.PostController` for `App.PostRoute`). However,
-        if you would like to define a specific controller to use, you can do so
-        using this property.
-        This is useful in many ways, as the controller specified will be:
-        * passed to the `setupController` method.
-        * used as the controller for the view being rendered by the route.
-        * returned from a call to `controllerFor` for the route.
-        @property controllerName
-        @type String
-        @default null
-        @since 1.4.0
-        */
-        controllerName: string;
-
-        /**
-        This hook is executed when the router completely exits this route. It is
-        not executed when the model for the route changes.
-        @method deactivate
-        */
-        deactivate: Function;
-
-        /**
-        Deserializes value of the query parameter based on defaultValueType
-        @method deserializeQueryParam
-        @param {Object} value
-        @param {String} urlKey
-        @param {String} defaultValueType
-        */
-        deserializeQueryParam(value: any, urlKey: string, defaultValueType: string): any;
-
-        /**
+      /**
         Disconnects a view that has been rendered into an outlet.
         You may pass any or all of the following options to `disconnectOutlet`:
         * `outlet`: the name of the outlet to clear (default: 'main')
         * `parentView`: the name of the view containing the outlet to clear
             (default: the view rendered by the parent route)
-
-        @method disconnectOutlet
-        @param {Object|String} options the options hash or outlet name
         */
-        disconnectOutlet(options: DisconnectOutletOptions | string): void;
+      disconnectOutlet(options: DisconnectOutletOptions | string): void;
 
-        /**
-        @method findModel
-        @param {String} type the model type
-        @param {Object} value the value passed to find
-        */
-        findModel(type: string, value: any): any;
-
-        /**
-        Generates a controller for a route.
-        If the optional model is passed then the controller type is determined automatically,
-        e.g., an ArrayController for arrays.
-
-        @method generateController
-        @param {String} name the name of the controller
-        @param {Object} model the model to infer the type of the controller (optional)
-        */
-        generateController(name: string, model: {}): Controller;
-
-        /**
+      /**
         Perform a synchronous transition into another route without attempting
         to resolve promises, update the URL, or abort any currently active
         asynchronous transitions (i.e. regular transitions caused by
@@ -1575,29 +1489,16 @@ namespace Ember {
         This method is handy for performing intermediate transitions on the
         way to a final destination route, and is called internally by the
         default implementations of the `error` and `loading` handlers.
-        @method intermediateTransitionTo
-        @param {String} name the name of the route
-        @param {...Object} models the model(s) to be used while transitioning
-        to the route.
-        @since 1.2.0
         */
-        intermediateTransitionTo(name: string, ...models: any[]): void;
+      intermediateTransitionTo(name: string, ...models: any[]): void;
 
-        /**
+      /**
         A hook you can implement to convert the URL into the model for
         this route.
-
-        @method model
-        @param {Object} params the parameters extracted from the URL
-        @param {Transition} transition
-        @return {Object|Promise} the model for this route. If
-            a promise is returned, the transition will pause until
-            the promise resolves, and the resolved value of the promise
-            will be used as the model for this route.
         */
         model(params: {}, transition: Transition): any | Rsvp.Promise<any>;
 
-        /**
+      /**
         Returns the model of a parent (or any ancestor) route
         in a route hierarchy.  During a transition, all routes
         must resolve a model object, and if a route
@@ -1605,30 +1506,16 @@ namespace Ember {
         resolve a model (or just reuse the model from a parent),
         it can call `this.modelFor(theNameOfParentRoute)` to
         retrieve it.
-
-        @method modelFor
-        @param {String} name the name of the route
-        @return {Object} the model object
         */
-        modelFor(name: string): {};
+      modelFor(name: string): {};
 
-        /**
+      /**
         Retrieves parameters, for current route using the state.params
         variable and getQueryParamsFor, using the supplied routeName.
-        @method paramsFor
-        @param {String} name
         */
-        paramsFor(name: string): any;
+      paramsFor(name: string): {};
 
-        /**
-        Configuration hash for this route's queryParams.
-        @property queryParams
-        @for Ember.Route
-        @type Hash
-        */
-        queryParams: {};
-
-        /**
+      /**
         Refresh the model on this route and any child routes, firing the
         `beforeModel`, `model`, and `afterModel` hooks in a similar fashion
         to how routes are entered when transitioning in from other route.
@@ -1641,14 +1528,10 @@ namespace Ember {
         Note that this will cause `model` hooks to fire even on routes
         that were provided a model object when the route was initially
         entered.
-        @method refresh
-        @return {Transition} the transition object associated with this
-            attempted transition
-        @since 1.4.0
         */
         redirect(): Transition;
 
-        /**
+      /**
         Refresh the model on this route and any child routes, firing the
         `beforeModel`, `model`, and `afterModel` hooks in a similar fashion
         to how routes are entered when transitioning in from other route.
@@ -1661,75 +1544,48 @@ namespace Ember {
         Note that this will cause `model` hooks to fire even on routes
         that were provided a model object when the route was initially
         entered.
-        @method refresh
-        @return {Transition} the transition object associated with this
-            attempted transition
-        @since 1.4.0
         */
         refresh(): Transition;
 
-        /**
+      /**
         `render` is used to render a template into a region of another template
         (indicated by an `{{outlet}}`). `render` is used both during the entry
         phase of routing (via the `renderTemplate` hook) and later in response to
         user interaction.
-
-        @method render
-        @param {String} name the name of the template to render
-        @param {Object} [options] the options
-        @param {String} [options.into] the template to render into,
-                        referenced by name. Defaults to the parent template
-        @param {String} [options.outlet] the outlet inside `options.template` to render into.
-                        Defaults to 'main'
-        @param {String|Object} [options.controller] the controller to use for this template,
-                        referenced by name or as a controller instance. Defaults to the Route's paired controller
-        @param {Object} [options.model] the model object to set on `options.controller`.
-                        Defaults to the return value of the Route's model hook
         */
-        render(name: string, options?: RenderOptions): void;
+      render(name: string, options?: RenderOptions): void;
 
-        /**
+      /**
         A hook you can use to render the template for the current route.
         This method is called with the controller for the current route and the
         model supplied by the `model` hook. By default, it renders the route's
         template, configured with the controller for the route.
         This method can be overridden to set up and render additional or
         alternative templates.
-
-        @method renderTemplate
-        @param {Object} controller the route's controller
-        @param {Object} model the route's model
         */
-        renderTemplate(controller: Controller, model: {}): void;
+      renderTemplate(controller: Controller, model: {}): void;
 
-        /**
+      /**
         Transition into another route while replacing the current URL, if possible.
         This will replace the current history entry instead of adding a new one.
         Beside that, it is identical to `transitionTo` in all other respects. See
         'transitionTo' for additional information regarding multiple models.
-
-        @method replaceWith
-        @param {String} name the name of the route or a URL
-        @param {...Object} models the model(s) or identifier(s) to be used while
-            transitioning to the route.
-        @return {Transition} the transition object associated with this
-            attempted transition
         */
-        replaceWith(name: string, ...models: any[]): void;
+      replaceWith(name: string, ...modelsAndOrOptions: any[]): Transition;
 
-        /**
+      /**
         A hook you can use to reset controller values either when the model
         changes or the route is exiting.
-
-        @method resetController
-        @param {Controller} controller instance
-        @param {Boolean} isExiting
-        @param {Object} transition
-        @since 1.7.0
         */
-        resetController(controller: Controller, isExiting: boolean, transition: any): void;
+      resetController(controller: Controller, isExiting: boolean, transition: any): void;
 
-        /**
+      /**
+        Sends an action to the router, which will delegate it to the currently active
+        route hierarchy per the bubbling rules explained under actions.
+        */
+      send(name: string, ...args: any[]): void;
+
+      /**
         A hook you can implement to convert the route's model into parameters
         for the URL.
 
@@ -1739,31 +1595,10 @@ namespace Ember {
         will return `Ember.getProperties(model, params)`
         This method is called when `transitionTo` is called with a context
         in order to populate the URL.
-        @method serialize
-        @param {Object} model the route's model
-        @param {Array} params an Array of parameter names for the current
-            route (in the example, `['post_id']`.
-        @return {Object} the serialized parameters
         */
-        serialize(model: {}, params: string[]): string;
+      serialize(model: {}, params: string[]): string;
 
-        /**
-        Serializes value of the query parameter based on defaultValueType
-        @method serializeQueryParam
-        @param {Object} value
-        @param {String} urlKey
-        @param {String} defaultValueType
-        */
-        serializeQueryParam(value: any, urlKey: string, defaultValueType: string): string;
-
-        /**
-        Serializes the query parameter key
-        @method serializeQueryParamKey
-        @param {String} controllerPropertyName
-        */
-        serializeQueryParamKey(controllerPropertyName: string): string;
-
-        /**
+      /**
         A hook you can use to setup the controller for the current route.
         This method is called with the controller for the current route and the
         model supplied by the `model` hook.
@@ -1773,37 +1608,10 @@ namespace Ember {
         prevent this default behavior. If you want to preserve that behavior
         when implementing your `setupController` function, make sure to call
         `_super`
-        @method setupController
-        @param {Controller} controller instance
-        @param {Object} model
         */
-        setupController(controller: Controller, model: {}): void;
+      setupController(controller: Controller, model: {}): void;
 
-        /**
-        Store property provides a hook for data persistence libraries to inject themselves.
-        By default, this store property provides the exact same functionality previously
-        in the model hook.
-        Currently, the required interface is:
-        `store.find(modelName, findArguments)`
-        @method store
-        @param {Object} store
-        */
-        store(store: any): any;
-
-        /**
-        The name of the template to use by default when rendering this routes
-        template.
-        This is similar with `viewName`, but is useful when you just want a custom
-        template without a view.
-
-        @property templateName
-        @type String
-        @default null
-        @since 1.4.0
-        */
-        templateName: string;
-
-        /**
+      /**
         Transition the application into another route. The route may
         be either a single route or route path
 
@@ -1830,114 +1638,88 @@ namespace Ember {
         @default null
         @since 1.4.0
         */
-        viewName: string;
+      transitionTo(name: string, ...object: any[]): Transition;
 
-        // ActionHandlerMixin methods
-
-        /**
-        Sends an action to the router, which will delegate it to the currently
-        active route hierarchy per the bubbling rules explained under actions
-
-        @method send
-        @param {String} actionName The action to trigger
-        @param {*} context a context to send with the action
+      // properties
+      /**
+        The controller associated with this route.
         */
-        send(name: string, ...args: any[]): void;
+      controller: Controller;
 
-        /**
-        The collection of functions, keyed by name, available on this
-        `ActionHandler` as action targets.
-        These functions will be invoked when a matching `{{action}}` is triggered
-        from within a template and the application's current route is this route.
-        Actions can also be invoked from other parts of your application
-        via `ActionHandler#send`.
-        The `actions` hash will inherit action handlers from
-        the `actions` hash defined on extended parent classes
-        or mixins rather than just replace the entire hash.
-
-        Within a Controller, Route, View or Component's action handler,
-        the value of the `this` context is the Controller, Route, View or
-        Component object:
-
-        It is also possible to call `this._super.apply(this, arguments)` from within an
-        action handler if it overrides a handler defined on a parent
-        class or mixin.
-
-        ## Bubbling
-        By default, an action will stop bubbling once a handler defined
-        on the `actions` hash handles it. To continue bubbling the action,
-        you must return `true` from the handler
-
-        @property actions
-        @type Hash
-        @default null
+      /**
+        The name of the controller to associate with this route.
+        By default, Ember will lookup a route's controller that matches the name
+        of the route (i.e. `App.PostController` for `App.PostRoute`). However,
+        if you would like to define a specific controller to use, you can do so
+        using this property.
+        This is useful in many ways, as the controller specified will be:
+        * passed to the `setupController` method.
+        * used as the controller for the view being rendered by the route.
+        * returned from a call to `controllerFor` for the route.
         */
-        actions: ActionsHash;
+      controllerName: string;
 
-        // Evented methods
-
-        /**
-        Subscribes to a named event with given function.
-
-        An optional target can be passed in as the 2nd argument that will
-        be set as the "this" for the callback. This is a good way to give your
-        function access to the object triggering the event. When the target
-        parameter is used the callback becomes the third argument.
-
-        @method on
-        @param {String} name The name of the event
-        @param {Object} [target] The "this" binding for the callback
-        @param {Function} method The callback to execute
-        @return this
+      /**
+        Configuration hash for this route's queryParams.
         */
-        on(name: string, target: any, method: Function): Evented;
+      queryParams: { [key: string]: RouteQueryParam };
 
-        /**
-        Subscribes a function to a named event and then cancels the subscription
-        after the first time the event is triggered. It is good to use ``one`` when
-        you only care about the first time an event has taken place.
-        This function takes an optional 2nd argument that will become the "this"
-        value for the callback. If this argument is passed then the 3rd argument
-        becomes the function.
+      /**
+       * The name of the route, dot-delimited
+       */
+      routeName: string;
 
-        @method one
-        @param {String} name The name of the event
-        @param {Object} [target] The "this" binding for the callback
-        @param {Function} method The callback to execute
-        @return this
+      /**
+        The name of the template to use by default when rendering this routes
+        template.
+        This is similar with `viewName`, but is useful when you just want a custom
+        template without a view.
         */
-        one(name: string, target: any, method: Function): Evented;
+      templateName: string;
 
-        /**
-        Triggers a named event for the object. Any additional arguments
-        will be passed as parameters to the functions that are subscribed to the
-        event.
-
-        @method trigger
-        @param {String} name The name of the event
-        @param {Object...} args Optional arguments to pass on
+      // events
+      /**
+        This hook is executed when the router enters the route. It is not executed
+        when the model for the route changes.
         */
-        trigger(name: string, ...args: string[]): void;
+      activate(): void;
 
-        /**
-        Cancels subscription for given name, target, and method.
-
-        @method off
-        @param {String} name The name of the event
-        @param {Object} target The target of the subscription
-        @param {Function} method The function of the subscription
-        @return this
+      /**
+        This hook is executed when the router completely exits this route. It is
+        not executed when the model for the route changes.
         */
-        off(name: string, target: any, method: Function): Evented;
+      deactivate(): void;
 
-        /**
-        Checks to see if object has any subscriptions for named event.
+      /**
+       * The didTransition action is fired after a transition has successfully been
+       * completed. This occurs after the normal model hooks (beforeModel, model,
+       * afterModel, setupController) have resolved. The didTransition action has
+       * no arguments, however, it can be useful for tracking page views or resetting
+       * state on the controller.
+       */
+      didTransition(): void;
 
-        @method has
-        @param {String} name The name of the event
-        @return {Boolean} does the object have a subscription for event
-        */
-        has(name: string): boolean;
+      /**
+       * When attempting to transition into a route, any of the hooks may return a promise
+       * that rejects, at which point an error action will be fired on the partially-entered
+       * routes, allowing for per-route error handling logic, or shared error handling logic
+       * defined on a parent route.
+       */
+      error(error: Error | any, transition: Transition): void;
+
+      /**
+       * The loading action is fired on the route when a route's model hook returns a
+       * promise that is not already resolved. The current Transition object is the first
+       * parameter and the route that triggered the loading event is the second parameter.
+       */
+      loading(transition: Transition, route: Route): void;
+
+      /**
+       * The willTransition action is fired at the beginning of any attempted transition
+       * with a Transition object as the sole argument. This action can be used for aborting,
+       * redirecting, or decorating the transition from the currently active routes.
+       */
+      willTransition(transition: Transition): void;
     }
     interface RouterMapContext {
         route(name: string, callback: (this: RouterMapContext) => void): void;

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -204,7 +204,7 @@ interface ActionHandler {
     **/
     actions: ActionsHash;
 }
-const ActionHandler: ActionHandler;
+const ActionHandler: Ember.Mixin<ActionHandler>;
 
 interface TriggerActionOptions {
     "action"?: string,

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1425,7 +1425,7 @@ namespace Ember {
       The `Ember.Route` class is used to define individual routes. Refer to
       the [routing guide](http://emberjs.com/guides/routing/) for documentation.
     */
-    interface Route extends Object, ActionHandler, Evented {
+    class Route extends Object.extend(ActionHandler, Evented) {
         /**
         This hook is executed when the router enters the route. It is not executed
         when the model for the route changes.
@@ -1939,7 +1939,6 @@ namespace Ember {
         */
         has(name: string): boolean;
     }
-    const Route: Mixin<Route>;
     interface RouterMapContext {
         route(name: string, callback: (this: RouterMapContext) => void): void;
         route(name: string, options?: { path?: string, resetNamespace?: boolean }, callback?: (this: RouterMapContext) => void): void;

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -234,8 +234,8 @@ interface ControllerMixin extends ActionHandler {
     replaceRoute(name: string, ...args: any[]): void;
     transitionToRoute(name: string, ...args: any[]): void;
     model: any;
-    queryParams: any;
-    target: any;
+    queryParams: string[] | { [key: string]: { type: string } }[];
+    target: Object;
 }
 const ControllerMixin: Ember.Mixin<ControllerMixin>;
 
@@ -634,17 +634,7 @@ namespace Ember {
       catalogEntriesByType(type: string): any[];
     }
 
-    class Controller extends Object.extend(ControllerMixin) {
-        replaceRoute(name: string, ...args: any[]): void;
-        transitionToRoute(name: string, ...args: any[]): void;
-        controllers: {};
-        model: any;
-        needs: string[];
-        queryParams: any;
-        target: any;
-        send(name: string, ...args: any[]): void;
-        actions: ActionsHash;
-    }
+    class Controller extends Object.extend(ControllerMixin) {}
     /**
     Implements some standard methods for copying an object. Add this mixin to any object you
     create that can create a copy of itself. This mixin is added automatically to the built-in array.

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1432,7 +1432,7 @@ namespace Ember {
       the [routing guide](http://emberjs.com/guides/routing/) for documentation.
     */
     class Route extends Object.extend(ActionHandler, Evented) {
-      //methods
+      // methods
       /**
         This hook is called after this route's model has resolved.
         It follows identical async/promise semantics to `beforeModel`

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -506,23 +506,23 @@ export namespace Ember {
         readDOMAttr(name: string): string;
         // properties
         /**
-        The WAI-ARIA role of the control represented by this view. For example, a button may have a
-        role of type 'button', or a pane may have a role of type 'alertdialog'. This property is
-        used by assistive software to help visually challenged users navigate rich web applications.
-        **/
+         * The WAI-ARIA role of the control represented by this view. For example, a button may have a
+         * role of type 'button', or a pane may have a role of type 'alertdialog'. This property is
+         * used by assistive software to help visually challenged users navigate rich web applications.
+         */
         ariaRole: string;
         /**
-        The HTML id of the component's element in the DOM. You can provide this value yourself but
-        it must be unique (just as in HTML):
-
-        If not manually set a default value will be provided by the framework. Once rendered an
-        element's elementId is considered immutable and you should never change it. If you need
-        to compute a dynamic value for the elementId, you should do this when the component or
-        element is being instantiated:
-        **/
+         * The HTML id of the component's element in the DOM. You can provide this value yourself but
+         * it must be unique (just as in HTML):
+         *
+         * If not manually set a default value will be provided by the framework. Once rendered an
+         * element's elementId is considered immutable and you should never change it. If you need
+         * to compute a dynamic value for the elementId, you should do this when the component or
+         * element is being instantiated:
+         */
         elementId: string;
         /**
-        If false, the view will appear hidden in DOM.
+         * If false, the view will appear hidden in DOM.
          */
         isVisible: boolean;
         /**
@@ -535,38 +535,38 @@ export namespace Ember {
          */
         layout: TemplateFactory | string;
         /**
-        Enables components to take a list of parameters as arguments.
-        **/
+         * Enables components to take a list of parameters as arguments.
+         */
         static positionalParams: string[] | string;
         // events
         /**
-        Called when the attributes passed into the component have been updated. Called both during the
-        initial render of a container and during a rerender. Can be used in place of an observer; code
-        placed here will be executed every time any attribute updates.
-        **/
+         * Called when the attributes passed into the component have been updated. Called both during the
+         * initial render of a container and during a rerender. Can be used in place of an observer; code
+         * placed here will be executed every time any attribute updates.
+         */
         didReceiveAttrs(): void;
         /**
-        Called after a component has been rendered, both on initial render and in subsequent rerenders.
-        **/
+         * Called after a component has been rendered, both on initial render and in subsequent rerenders.
+         */
         didRender(): void;
         /**
-        Called when the component has updated and rerendered itself. Called only during a rerender,
-        not during an initial render.
-        **/
+         * Called when the component has updated and rerendered itself. Called only during a rerender,
+         * not during an initial render.
+         */
         didUpdate(): void;
         /**
-        Called when the attributes passed into the component have been changed. Called only during a
-        rerender, not during an initial render.
-        **/
+         * Called when the attributes passed into the component have been changed. Called only during a
+         * rerender, not during an initial render.
+         */
         didUpdateAttrs(): void;
         /**
-        Called before a component has been rendered, both on initial render and in subsequent rerenders.
-        **/
+         * Called before a component has been rendered, both on initial render and in subsequent rerenders.
+         */
         willRender(): void;
         /**
-        Called when the component is about to update and rerender itself. Called only during a rerender,
-        not during an initial render.
-        **/
+         * Called when the component is about to update and rerender itself. Called only during a rerender,
+         * not during an initial render.
+         */
         willUpdate(): void;
     }
     /**
@@ -855,7 +855,7 @@ export namespace Ember {
     }
     /**
     The DataAdapter helps a data persistence library interface with tools
-     that debug Ember such as the Ember Extension for Chrome and Firefox.
+    that debug Ember such as the Ember Extension for Chrome and Firefox.
     */
     class DataAdapter extends Object {
         acceptsModelName: any;
@@ -1456,32 +1456,12 @@ export namespace Ember {
         */
         beforeModel(transition: Transition): Rsvp.Promise<any>;
 
-      /**
-        Returns the controller for a particular route or name.
-        The controller instance must already have been created, either through entering the
-        associated route or using `generateController`.
-        */
-      controllerFor(name: string): Controller;
-
-      /**
-        Disconnects a view that has been rendered into an outlet.
-        You may pass any or all of the following options to `disconnectOutlet`:
-        * `outlet`: the name of the outlet to clear (default: 'main')
-        * `parentView`: the name of the view containing the outlet to clear
-            (default: the view rendered by the parent route)
-        */
-      disconnectOutlet(options: DisconnectOutletOptions | string): void;
-
-      /**
-        Perform a synchronous transition into another route without attempting
-        to resolve promises, update the URL, or abort any currently active
-        asynchronous transitions (i.e. regular transitions caused by
-        `transitionTo` or URL changes).
-        This method is handy for performing intermediate transitions on the
-        way to a final destination route, and is called internally by the
-        default implementations of the `error` and `loading` handlers.
-        */
-      intermediateTransitionTo(name: string, ...models: any[]): void;
+        /**
+         * Returns the controller for a particular route or name.
+         * The controller instance must already have been created, either through entering the
+         * associated route or using `generateController`.
+         */
+        controllerFor(name: string): Controller;
 
       /**
         A hook you can implement to convert the URL into the model for
@@ -1489,228 +1469,215 @@ export namespace Ember {
         */
         model(params: {}, transition: Transition): any | Rsvp.Promise<any>;
 
-      /**
-        Returns the model of a parent (or any ancestor) route
-        in a route hierarchy.  During a transition, all routes
-        must resolve a model object, and if a route
-        needs access to a parent route's model in order to
-        resolve a model (or just reuse the model from a parent),
-        it can call `this.modelFor(theNameOfParentRoute)` to
-        retrieve it.
-        */
-      modelFor(name: string): {};
+        /**
+         * Returns the model of a parent (or any ancestor) route
+         * in a route hierarchy.  During a transition, all routes
+         * must resolve a model object, and if a route
+         * needs access to a parent route's model in order to
+         * resolve a model (or just reuse the model from a parent),
+         * it can call `this.modelFor(theNameOfParentRoute)` to
+         * retrieve it.
+         */
+        modelFor(name: string): {};
 
-      /**
-        Retrieves parameters, for current route using the state.params
-        variable and getQueryParamsFor, using the supplied routeName.
-        */
-      paramsFor(name: string): {};
+        /**
+         * Retrieves parameters, for current route using the state.params
+         * variable and getQueryParamsFor, using the supplied routeName.
+         */
+        paramsFor(name: string): {};
 
-      /**
-        Refresh the model on this route and any child routes, firing the
-        `beforeModel`, `model`, and `afterModel` hooks in a similar fashion
-        to how routes are entered when transitioning in from other route.
-        The current route params (e.g. `article_id`) will be passed in
-        to the respective model hooks, and if a different model is returned,
-        `setupController` and associated route hooks will re-fire as well.
-        An example usage of this method is re-querying the server for the
-        latest information using the same parameters as when the route
-        was first entered.
-        Note that this will cause `model` hooks to fire even on routes
-        that were provided a model object when the route was initially
-        entered.
-        */
+        /**
+         * Refresh the model on this route and any child routes, firing the
+         * `beforeModel`, `model`, and `afterModel` hooks in a similar fashion
+         * to how routes are entered when transitioning in from other route.
+         * The current route params (e.g. `article_id`) will be passed in
+         * to the respective model hooks, and if a different model is returned,
+         * `setupController` and associated route hooks will re-fire as well.
+         * An example usage of this method is re-querying the server for the
+         * latest information using the same parameters as when the route
+         * was first entered.
+         * Note that this will cause `model` hooks to fire even on routes
+         * that were provided a model object when the route was initially
+         * entered.
+         */
         redirect(): Transition;
 
-      /**
-        Refresh the model on this route and any child routes, firing the
-        `beforeModel`, `model`, and `afterModel` hooks in a similar fashion
-        to how routes are entered when transitioning in from other route.
-        The current route params (e.g. `article_id`) will be passed in
-        to the respective model hooks, and if a different model is returned,
-        `setupController` and associated route hooks will re-fire as well.
-        An example usage of this method is re-querying the server for the
-        latest information using the same parameters as when the route
-        was first entered.
-        Note that this will cause `model` hooks to fire even on routes
-        that were provided a model object when the route was initially
-        entered.
-        */
+        /**
+         * Refresh the model on this route and any child routes, firing the
+         * `beforeModel`, `model`, and `afterModel` hooks in a similar fashion
+         * to how routes are entered when transitioning in from other route.
+         * The current route params (e.g. `article_id`) will be passed in
+         * to the respective model hooks, and if a different model is returned,
+         * `setupController` and associated route hooks will re-fire as well.
+         * An example usage of this method is re-querying the server for the
+         * latest information using the same parameters as when the route
+         * was first entered.
+         * Note that this will cause `model` hooks to fire even on routes
+         * that were provided a model object when the route was initially
+         * entered.
+         */
         refresh(): Transition;
 
-      /**
-        `render` is used to render a template into a region of another template
-        (indicated by an `{{outlet}}`). `render` is used both during the entry
-        phase of routing (via the `renderTemplate` hook) and later in response to
-        user interaction.
-        */
-      render(name: string, options?: RenderOptions): void;
+        /**
+         * `render` is used to render a template into a region of another template
+         * (indicated by an `{{outlet}}`). `render` is used both during the entry
+         * phase of routing (via the `renderTemplate` hook) and later in response to
+         * user interaction.
+         */
+        render(name: string, options?: RenderOptions): void;
 
-      /**
-        A hook you can use to render the template for the current route.
-        This method is called with the controller for the current route and the
-        model supplied by the `model` hook. By default, it renders the route's
-        template, configured with the controller for the route.
-        This method can be overridden to set up and render additional or
-        alternative templates.
-        */
-      renderTemplate(controller: Controller, model: {}): void;
+        /**
+         * A hook you can use to render the template for the current route.
+         * This method is called with the controller for the current route and the
+         * model supplied by the `model` hook. By default, it renders the route's
+         * template, configured with the controller for the route.
+         * This method can be overridden to set up and render additional or
+         * alternative templates.
+         */
+        renderTemplate(controller: Controller, model: {}): void;
 
-      /**
-        Transition into another route while replacing the current URL, if possible.
-        This will replace the current history entry instead of adding a new one.
-        Beside that, it is identical to `transitionTo` in all other respects. See
-        'transitionTo' for additional information regarding multiple models.
-        */
-      replaceWith(name: string, ...args: any[]): Transition;
+        /**
+         * Transition into another route while replacing the current URL, if possible.
+         * This will replace the current history entry instead of adding a new one.
+         * Beside that, it is identical to `transitionTo` in all other respects. See
+         * 'transitionTo' for additional information regarding multiple models.
+         */
+        replaceWith(name: string, ...args: any[]): Transition;
 
-      /**
-        A hook you can use to reset controller values either when the model
-        changes or the route is exiting.
-        */
-      resetController(controller: Controller, isExiting: boolean, transition: any): void;
+        /**
+         * A hook you can use to reset controller values either when the model
+         * changes or the route is exiting.
+         */
+        resetController(controller: Controller, isExiting: boolean, transition: any): void;
 
-      /**
-        Sends an action to the router, which will delegate it to the currently active
-        route hierarchy per the bubbling rules explained under actions.
-        */
-      send(name: string, ...args: any[]): void;
+        /**
+         * Sends an action to the router, which will delegate it to the currently active
+         * route hierarchy per the bubbling rules explained under actions.
+         */
+        send(name: string, ...args: any[]): void;
 
-      /**
-        A hook you can implement to convert the route's model into parameters
-        for the URL.
+        /**
+         * A hook you can implement to convert the route's model into parameters
+         * for the URL.
+         *
+         * The default `serialize` method will insert the model's `id` into the
+         * route's dynamic segment (in this case, `:post_id`) if the segment contains '_id'.
+         * If the route has multiple dynamic segments or does not contain '_id', `serialize`
+         * will return `Ember.getProperties(model, params)`
+         * This method is called when `transitionTo` is called with a context
+         * in order to populate the URL.
+         */
+        serialize(model: {}, params: string[]): string;
 
-        The default `serialize` method will insert the model's `id` into the
-        route's dynamic segment (in this case, `:post_id`) if the segment contains '_id'.
-        If the route has multiple dynamic segments or does not contain '_id', `serialize`
-        will return `Ember.getProperties(model, params)`
-        This method is called when `transitionTo` is called with a context
-        in order to populate the URL.
-        */
-      serialize(model: {}, params: string[]): string;
+        /**
+         * A hook you can use to setup the controller for the current route.
+         * This method is called with the controller for the current route and the
+         * model supplied by the `model` hook.
+         * By default, the `setupController` hook sets the `model` property of
+         * the controller to the `model`.
+         * If you implement the `setupController` hook in your Route, it will
+         * prevent this default behavior. If you want to preserve that behavior
+         * when implementing your `setupController` function, make sure to call
+         * `_super`
+         */
+        setupController(controller: Controller, model: {}): void;
 
-      /**
-        A hook you can use to setup the controller for the current route.
-        This method is called with the controller for the current route and the
-        model supplied by the `model` hook.
-        By default, the `setupController` hook sets the `model` property of
-        the controller to the `model`.
-        If you implement the `setupController` hook in your Route, it will
-        prevent this default behavior. If you want to preserve that behavior
-        when implementing your `setupController` function, make sure to call
-        `_super`
-        */
-      setupController(controller: Controller, model: {}): void;
-
-      /**
-        Transition the application into another route. The route may
-        be either a single route or route path
-
-        @method transitionTo
-        @param {String} name the name of the route or a URL
-        @param {...Object} models the model(s) or identifier(s) to be used while
-        transitioning to the route.
-        @param {Object} [options] optional hash with a queryParams property
-        containing a mapping of query parameters
-        @return {Transition} the transition object associated with this
-        attempted transition
-        */
+        /**
+         * Transition the application into another route. The route may
+         * be either a single route or route path
+         */
         transitionTo(name: string, ...object: any[]): Transition;
 
         /**
-        The name of the view to use by default when rendering this routes template.
-        When rendering a template, the route will, by default, determine the
-        template and view to use from the name of the route itself. If you need to
-        define a specific view, set this property.
-        This is useful when multiple routes would benefit from using the same view
-        because it doesn't require a custom `renderTemplate` method.
-        @property viewName
-        @type String
-        @default null
-        @since 1.4.0
-        */
-      transitionTo(name: string, ...object: any[]): Transition;
+         * The name of the view to use by default when rendering this routes template.
+         * When rendering a template, the route will, by default, determine the
+         * template and view to use from the name of the route itself. If you need to
+         * define a specific view, set this property.
+         * This is useful when multiple routes would benefit from using the same view
+         * because it doesn't require a custom `renderTemplate` method.
+         */
+        transitionTo(name: string, ...object: any[]): Transition;
 
-      // properties
-      /**
-        The controller associated with this route.
-        */
-      controller: Controller;
+        // properties
+        /**
+         * The controller associated with this route.
+         */
+        controller: Controller;
 
-      /**
-        The name of the controller to associate with this route.
-        By default, Ember will lookup a route's controller that matches the name
-        of the route (i.e. `App.PostController` for `App.PostRoute`). However,
-        if you would like to define a specific controller to use, you can do so
-        using this property.
-        This is useful in many ways, as the controller specified will be:
-        * passed to the `setupController` method.
-        * used as the controller for the view being rendered by the route.
-        * returned from a call to `controllerFor` for the route.
-        */
-      controllerName: string;
+        /**
+         * The name of the controller to associate with this route.
+         * By default, Ember will lookup a route's controller that matches the name
+         * of the route (i.e. `App.PostController` for `App.PostRoute`). However,
+         * if you would like to define a specific controller to use, you can do so
+         * using this property.
+         * This is useful in many ways, as the controller specified will be:
+         * * p assed to the `setupController` method.
+         * * used as the controller for the view being rendered by the route.
+         * * returned from a call to `controllerFor` for the route.
+         */
+        controllerName: string;
 
-      /**
-        Configuration hash for this route's queryParams.
-        */
-      queryParams: { [key: string]: RouteQueryParam };
+        /**
+         * Configuration hash for this route's queryParams.
+         */
+        queryParams: { [key: string]: RouteQueryParam };
 
-      /**
-       * The name of the route, dot-delimited
-       */
-      routeName: string;
+        /**
+         * The name of the route, dot-delimited
+         */
+        routeName: string;
 
-      /**
-        The name of the template to use by default when rendering this routes
-        template.
-        This is similar with `viewName`, but is useful when you just want a custom
-        template without a view.
-        */
-      templateName: string;
+        /**
+         * The name of the template to use by default when rendering this routes
+         * template.
+         * This is similar with `viewName`, but is useful when you just want a custom
+         * template without a view.
+         */
+        templateName: string;
 
-      // events
-      /**
-        This hook is executed when the router enters the route. It is not executed
-        when the model for the route changes.
-        */
-      activate(): void;
+        // events
+        /**
+         * This hook is executed when the router enters the route. It is not executed
+         * when the model for the route changes.
+         */
+        activate(): void;
 
-      /**
-        This hook is executed when the router completely exits this route. It is
-        not executed when the model for the route changes.
-        */
-      deactivate(): void;
+        /**
+         * This hook is executed when the router completely exits this route. It is
+         * not executed when the model for the route changes.
+         */
+        deactivate(): void;
 
-      /**
-       * The didTransition action is fired after a transition has successfully been
-       * completed. This occurs after the normal model hooks (beforeModel, model,
-       * afterModel, setupController) have resolved. The didTransition action has
-       * no arguments, however, it can be useful for tracking page views or resetting
-       * state on the controller.
-       */
-      didTransition(): void;
+        /**
+         * The didTransition action is fired after a transition has successfully been
+         * completed. This occurs after the normal model hooks (beforeModel, model,
+         * afterModel, setupController) have resolved. The didTransition action has
+         * no arguments, however, it can be useful for tracking page views or resetting
+         * state on the controller.
+         */
+        didTransition(): void;
 
-      /**
-       * When attempting to transition into a route, any of the hooks may return a promise
-       * that rejects, at which point an error action will be fired on the partially-entered
-       * routes, allowing for per-route error handling logic, or shared error handling logic
-       * defined on a parent route.
-       */
-      error(error: Error | any, transition: Transition): void;
+        /**
+         * When attempting to transition into a route, any of the hooks may return a promise
+         * that rejects, at which point an error action will be fired on the partially-entered
+         * routes, allowing for per-route error handling logic, or shared error handling logic
+         * defined on a parent route.
+         */
+        error(error: Error | any, transition: Transition): void;
 
-      /**
-       * The loading action is fired on the route when a route's model hook returns a
-       * promise that is not already resolved. The current Transition object is the first
-       * parameter and the route that triggered the loading event is the second parameter.
-       */
-      loading(transition: Transition, route: Route): void;
+        /**
+         * The loading action is fired on the route when a route's model hook returns a
+         * promise that is not already resolved. The current Transition object is the first
+         * parameter and the route that triggered the loading event is the second parameter.
+         */
+        loading(transition: Transition, route: Route): void;
 
-      /**
-       * The willTransition action is fired at the beginning of any attempted transition
-       * with a Transition object as the sole argument. This action can be used for aborting,
-       * redirecting, or decorating the transition from the currently active routes.
-       */
-      willTransition(transition: Transition): void;
+        /**
+         * The willTransition action is fired at the beginning of any attempted transition
+         * with a Transition object as the sole argument. This action can be used for aborting,
+         * redirecting, or decorating the transition from the currently active routes.
+         */
+        willTransition(transition: Transition): void;
     }
     interface RouterMapContext {
         route(name: string, callback: (this: RouterMapContext) => void): void;

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -207,9 +207,9 @@ interface ActionHandler {
 const ActionHandler: Ember.Mixin<ActionHandler>;
 
 interface TriggerActionOptions {
-    "action"?: string,
-    "target"?: Ember.Object,
-    "actionContext"?: Ember.Object
+    "action"?: string;
+    "target"?: Ember.Object;
+    "actionContext"?: Ember.Object;
 }
 /**
 Ember.TargetActionSupport is a mixin that can be included in a class to add a triggerAction method

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1423,8 +1423,8 @@ export namespace Ember {
       the [routing guide](http://emberjs.com/guides/routing/) for documentation.
     */
     class Route extends Object.extend(ActionHandler, Evented) {
-      // methods
-      /**
+        // methods
+        /**
         This hook is called after this route's model has resolved.
         It follows identical async/promise semantics to `beforeModel`
         but is provided the route's resolved model in addition to
@@ -1434,7 +1434,7 @@ export namespace Ember {
         */
         afterModel(resolvedModel: any, transition: Transition): Rsvp.Promise<any>;
 
-      /**
+        /**
         This hook is the first of the route entry validation hooks
         called when an attempt is made to transition into a route
         or one of its children. It is called before `model` and
@@ -1463,10 +1463,15 @@ export namespace Ember {
          */
         controllerFor(name: string): Controller;
 
-      /**
-        A hook you can implement to convert the URL into the model for
-        this route.
-        */
+        /**
+         * Disconnects a view that has been rendered into an outlet.
+         */
+        disconnectOutlet(options: string | {outlet?: string, parentView?: string}): void;
+
+        /**
+         * A hook you can implement to convert the URL into the model for
+         * this route.
+         */
         model(params: {}, transition: Transition): any | Rsvp.Promise<any>;
 
         /**

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -12,6 +12,7 @@ declare module 'ember' {
 // Capitalization is intentional: this makes it much easier to re-export RSVP on
 // the Ember namespace.
 import Rsvp from 'rsvp';
+import { TemplateFactory } from 'htmlbars-inline-precompile';
 
 // Get an alias to the global Array type to use in inner scope below.
 type GlobalArray<T> = T[];
@@ -525,14 +526,14 @@ export namespace Ember {
          */
         isVisible: boolean;
         /**
-        A component may contain a layout. A layout is a regular template but supersedes the template
-        property during rendering. It is the responsibility of the layout template to retrieve the
-        template property from the component (or alternatively, call Handlebars.helpers.yield,
-        {{yield}}) to render it in the correct location. This is useful for a component that has a
-        shared wrapper, but which delegates the rendering of the contents of the wrapper to the
-        template property on a subclass.
-        **/
-        layout: string; // @todo: https://github.com/emberjs/ember.js/blob/v2.14.1/packages/ember-glimmer/lib/component.js#L811
+         * A component may contain a layout. A layout is a regular template but supersedes the template
+         * property during rendering. It is the responsibility of the layout template to retrieve the
+         * template property from the component (or alternatively, call Handlebars.helpers.yield,
+         * {{yield}}) to render it in the correct location. This is useful for a component that has a
+         * shared wrapper, but which delegates the rendering of the contents of the wrapper to the
+         * template property on a subclass.
+         */
+        layout: TemplateFactory | string;
         /**
         Enables components to take a list of parameters as arguments.
         **/

--- a/types/ember/test/array.ts
+++ b/types/ember/test/array.ts
@@ -20,7 +20,7 @@ assertType<Person[]>(people.filterBy('isHappy'));
 assertType<typeof people>(people.get('[]'));
 assertType<Person>(people.get('[]').get('firstObject'));
 
-assertType<boolean[]>(people.mapBy('isHappy'));
+assertType<Ember.Array<boolean>>(people.mapBy('isHappy'));
 assertType<any[]>(people.mapBy('name.length'));
 
 const last = people.get('lastObject');

--- a/types/ember/test/component.ts
+++ b/types/ember/test/component.ts
@@ -1,19 +1,19 @@
 import Ember from 'ember';
 import Component from '@ember/component';
-import Object, { computed } from '@ember/object'
+import Object, { computed } from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 import { assertType } from "./lib/assert";
 
 Component.extend({
-    layout: hbs`
+  layout: hbs`
         <div>
           {{yield}}
         </div>
-    `
+    `,
 });
 
 Component.extend({
-    layout: 'my-layout'
+  layout: 'my-layout',
 });
 
 const MyComponent = Component.extend();
@@ -26,92 +26,98 @@ const component1 = Component.extend({
     },
   },
 });
+class Comp1 extends Component {
+  name: string = '';
+  hello(name: string) {
+      this.set('name', name);
+  }
+}
 
-const component2 = Component.extend({
-  tagName: 'em',
-});
+class Comp2 extends Component {
+  tagName: 'em';
+}
 
-const component3 = Component.extend({
-  classNames: ['my-class', 'my-other-class'],
-});
+class Comp3 extends Component {
+  classNames: ['my-class', 'my-other-class'];
+}
 
-const component4 = Component.extend({
-  classNameBindings: ['propertyA', 'propertyB'],
-  propertyA: 'from-a',
-  propertyB: computed(function() {
+class Comp4 extends Component {
+  classNameBindings = ['propertyA', 'propertyB'];
+  propertyA = 'from-a';
+  propertyB = computed(function() {
     if ('someLogic') {
       return 'from-b';
     }
-  }),
-});
+  });
+}
 
-const component5 = Component.extend({
-  classNameBindings: ['hovered'],
-  hovered: true,
-});
+class Comp5 extends Component {
+  classNameBindings = ['hovered'];
+  hovered = true;
+}
 
-const component6 = Component.extend({
-  classNameBindings: ['messages.empty'],
-  messages: Object.create({
+class Comp6 extends Component {
+  classNameBindings = ['messages.empty'];
+  messages = Object.create({
     empty: true,
-  }),
-});
+  });
+}
 
-const component7 = Component.extend({
-  classNameBindings: ['isEnabled:enabled:disabled'],
-  isEnabled: true,
-});
+class Comp7 extends Component {
+  classNameBindings = ['isEnabled:enabled:disabled'];
+  isEnabled = true;
+}
 
-const component8 = Component.extend({
-  classNameBindings: ['isEnabled::disabled'],
-  isEnabled: true,
-});
+class Comp8 extends Component {
+  classNameBindings = ['isEnabled::disabled'];
+  isEnabled = true;
+}
 
-const component9 = Component.extend({
-  tagName: 'a',
-  attributeBindings: ['href'],
-  href: 'http://google.com',
-});
+class Comp9 extends Component {
+  tagName = 'a';
+  attributeBindings = ['href'];
+  href: 'http://google.com';
+}
 
-const component10 = Component.extend({
-  tagName: 'a',
-  attributeBindings: ['url:href'],
-  url: 'http://google.com',
-});
+class Comp10 extends Component {
+  tagName = 'a';
+  attributeBindings = ['url:href'];
+  url = 'http://google.com';
+}
 
-const component11 = Component.extend({
-  tagName: 'use',
-  attributeBindings: ['xlinkHref:xlink:href'],
-  xlinkHref: '#triangle',
-});
+class Comp11 extends Component {
+  tagName = 'use';
+  attributeBindings = ['xlinkHref:xlink:href'];
+  xlinkHref = '#triangle';
+}
 
-const component12 = Component.extend({
-  tagName: 'input',
-  attributeBindings: ['disabled'],
-  disabled: false,
-});
+class Comp12 extends Component {
+  tagName = 'input';
+  attributeBindings = ['disabled'];
+  disabled = false;
+}
 
-const component13 = Component.extend({
-  tagName: 'input',
-  attributeBindings: ['disabled'],
-  disabled: computed(function() {
+class Comp13 extends Component {
+  tagName = 'input';
+  attributeBindings = ['disabled'];
+  disabled = computed(function() {
     if ('someLogic') {
       return true;
     } else {
       return false;
     }
-  }),
-});
+  });
+}
 
-const component14 = Component.extend({
-  tagName: 'form',
-  attributeBindings: ['novalidate'],
-  novalidate: null,
-});
+class Comp14 extends Component {
+  tagName = 'form';
+  attributeBindings = ['novalidate'];
+  novalidate = null;
+}
 
-const component15 = Component.extend({
+class Comp15 extends Component {
   click(event: object) {
     // will be called when an instance's
     // rendered element is clicked
-  },
-});
+  }
+}

--- a/types/ember/test/component.ts
+++ b/types/ember/test/component.ts
@@ -45,7 +45,7 @@ class Comp4 extends Component {
   classNameBindings = ['propertyA', 'propertyB'];
   propertyA = 'from-a';
   propertyB = computed(() => {
-    if ('someLogic') {
+    if (!this.get('propertyA')) {
       return 'from-b';
     }
   });

--- a/types/ember/test/component.ts
+++ b/types/ember/test/component.ts
@@ -27,7 +27,7 @@ const component1 = Component.extend({
   },
 });
 class Comp1 extends Component {
-  name: string = '';
+  name = '';
   hello(name: string) {
       this.set('name', name);
   }
@@ -44,7 +44,7 @@ class Comp3 extends Component {
 class Comp4 extends Component {
   classNameBindings = ['propertyA', 'propertyB'];
   propertyA = 'from-a';
-  propertyB = computed(function() {
+  propertyB = computed(() => {
     if ('someLogic') {
       return 'from-b';
     }
@@ -100,7 +100,7 @@ class Comp12 extends Component {
 class Comp13 extends Component {
   tagName = 'input';
   attributeBindings = ['disabled'];
-  disabled = computed(function() {
+  disabled = computed(() => {
     if ('someLogic') {
       return true;
     } else {

--- a/types/ember/test/component.ts
+++ b/types/ember/test/component.ts
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import Component from '@ember/component';
+import Object, { computed } from '@ember/object'
 import hbs from 'htmlbars-inline-precompile';
 import { assertType } from "./lib/assert";
 
@@ -17,3 +18,100 @@ Component.extend({
 
 const MyComponent = Component.extend();
 assertType<string | string[]>(Ember.get(MyComponent, 'positionalParams'));
+
+const component1 = Component.extend({
+  actions: {
+    hello(name: string) {
+      console.log('Hello', name);
+    },
+  },
+});
+
+const component2 = Component.extend({
+  tagName: 'em',
+});
+
+const component3 = Component.extend({
+  classNames: ['my-class', 'my-other-class'],
+});
+
+const component4 = Component.extend({
+  classNameBindings: ['propertyA', 'propertyB'],
+  propertyA: 'from-a',
+  propertyB: computed(function() {
+    if ('someLogic') {
+      return 'from-b';
+    }
+  }),
+});
+
+const component5 = Component.extend({
+  classNameBindings: ['hovered'],
+  hovered: true,
+});
+
+const component6 = Component.extend({
+  classNameBindings: ['messages.empty'],
+  messages: Object.create({
+    empty: true,
+  }),
+});
+
+const component7 = Component.extend({
+  classNameBindings: ['isEnabled:enabled:disabled'],
+  isEnabled: true,
+});
+
+const component8 = Component.extend({
+  classNameBindings: ['isEnabled::disabled'],
+  isEnabled: true,
+});
+
+const component9 = Component.extend({
+  tagName: 'a',
+  attributeBindings: ['href'],
+  href: 'http://google.com',
+});
+
+const component10 = Component.extend({
+  tagName: 'a',
+  attributeBindings: ['url:href'],
+  url: 'http://google.com',
+});
+
+const component11 = Component.extend({
+  tagName: 'use',
+  attributeBindings: ['xlinkHref:xlink:href'],
+  xlinkHref: '#triangle',
+});
+
+const component12 = Component.extend({
+  tagName: 'input',
+  attributeBindings: ['disabled'],
+  disabled: false,
+});
+
+const component13 = Component.extend({
+  tagName: 'input',
+  attributeBindings: ['disabled'],
+  disabled: computed(function() {
+    if ('someLogic') {
+      return true;
+    } else {
+      return false;
+    }
+  }),
+});
+
+const component14 = Component.extend({
+  tagName: 'form',
+  attributeBindings: ['novalidate'],
+  novalidate: null,
+});
+
+const component15 = Component.extend({
+  click(event: object) {
+    // will be called when an instance's
+    // rendered element is clicked
+  },
+});

--- a/types/ember/test/component.ts
+++ b/types/ember/test/component.ts
@@ -26,98 +26,99 @@ const component1 = Component.extend({
     },
   },
 });
-class Comp1 extends Component {
-  name = '';
+
+Component.extend({
+  name: '',
   hello(name: string) {
-      this.set('name', name);
-  }
-}
+    this.set('name', name);
+  },
+});
 
-class Comp2 extends Component {
-  tagName: 'em';
-}
+Component.extend({
+  tagName: 'em',
+});
 
-class Comp3 extends Component {
-  classNames: ['my-class', 'my-other-class'];
-}
+Component.extend({
+  classNames: ['my-class', 'my-other-class'],
+});
 
-class Comp4 extends Component {
-  classNameBindings = ['propertyA', 'propertyB'];
-  propertyA = 'from-a';
-  propertyB = computed(() => {
+Component.extend({
+  classNameBindings: ['propertyA', 'propertyB'],
+  propertyA: 'from-a',
+  propertyB: computed(function() {
     if (!this.get('propertyA')) {
       return 'from-b';
     }
-  });
-}
+  }),
+});
 
-class Comp5 extends Component {
-  classNameBindings = ['hovered'];
-  hovered = true;
-}
+Component.extend({
+  classNameBindings: ['hovered'],
+  hovered: true,
+});
 
-class Comp6 extends Component {
-  classNameBindings = ['messages.empty'];
-  messages = Object.create({
+Component.extend({
+  classNameBindings: ['messages.empty'],
+  messages: Object.create({
     empty: true,
-  });
-}
+  }),
+});
 
-class Comp7 extends Component {
-  classNameBindings = ['isEnabled:enabled:disabled'];
-  isEnabled = true;
-}
+Component.extend({
+  classNameBindings: ['isEnabled:enabled:disabled'],
+  isEnabled: true,
+});
 
-class Comp8 extends Component {
-  classNameBindings = ['isEnabled::disabled'];
-  isEnabled = true;
-}
+Component.extend({
+  classNameBindings: ['isEnabled::disabled'],
+  isEnabled: true,
+});
 
-class Comp9 extends Component {
-  tagName = 'a';
-  attributeBindings = ['href'];
-  href: 'http://google.com';
-}
+Component.extend({
+  tagName: 'a',
+  attributeBindings: ['href'],
+  href: 'http://google.com',
+});
 
-class Comp10 extends Component {
-  tagName = 'a';
-  attributeBindings = ['url:href'];
-  url = 'http://google.com';
-}
+Component.extend({
+  tagName: 'a',
+  attributeBindings: ['url:href'],
+  url: 'http://google.com',
+});
 
-class Comp11 extends Component {
-  tagName = 'use';
-  attributeBindings = ['xlinkHref:xlink:href'];
-  xlinkHref = '#triangle';
-}
+Component.extend({
+  tagName: 'use',
+  attributeBindings: ['xlinkHref:xlink:href'],
+  xlinkHref: '#triangle',
+});
 
-class Comp12 extends Component {
-  tagName = 'input';
-  attributeBindings = ['disabled'];
-  disabled = false;
-}
+Component.extend({
+  tagName: 'input',
+  attributeBindings: ['disabled'],
+  disabled: false,
+});
 
-class Comp13 extends Component {
-  tagName = 'input';
-  attributeBindings = ['disabled'];
-  disabled = computed(() => {
+Component.extend({
+  tagName: 'input',
+  attributeBindings: ['disabled'],
+  disabled: computed(() => {
     if ('someLogic') {
       return true;
     } else {
       return false;
     }
-  });
-}
+  }),
+});
 
-class Comp14 extends Component {
-  tagName = 'form';
-  attributeBindings = ['novalidate'];
-  novalidate = null;
-}
+Component.extend({
+  tagName: 'form',
+  attributeBindings: ['novalidate'],
+  novalidate: null,
+});
 
-class Comp15 extends Component {
+Component.extend({
   click(event: object) {
     // will be called when an instance's
     // rendered element is clicked
-  }
-}
+  },
+});

--- a/types/ember/test/controller.ts
+++ b/types/ember/test/controller.ts
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+
+class MyController extends Controller {
+  queryParams = ['category'];
+  category = null;
+  isExpanded = false;
+
+  toggleBody() {
+    this.toggleProperty('isExpanded');
+  }
+}

--- a/types/ember/test/controller.ts
+++ b/types/ember/test/controller.ts
@@ -1,11 +1,11 @@
 import Controller from '@ember/controller';
 
-class MyController extends Controller {
-  queryParams = ['category'];
-  category = null;
-  isExpanded = false;
+Controller.extend ({
+  queryParams: ['category'],
+  category: null,
+  isExpanded: false,
 
   toggleBody() {
     this.toggleProperty('isExpanded');
   }
-}
+});

--- a/types/ember/test/route.ts
+++ b/types/ember/test/route.ts
@@ -1,12 +1,95 @@
 import Route from '@ember/routing/route';
-import Ember from 'ember';
-const { Logger } = Ember;
+import Object from '@ember/object';
+import Array from '@ember/array';
+import Ember from 'ember'; // Transition isn't currently exposed
 
-class Route1 extends Route {
-  queryParams = {
-    category: {
-      refreshModel: true,
-    },
-  };
-  templateName: 'posts/favorite-posts';
+interface Post extends Object {}
+
+interface Posts extends Array<Post> {
+    length: number;
+    firstObject: Post;
 }
+
+Route.extend({
+  beforeModel(transition: Ember.Transition) {
+    this.transitionTo('someOtherRoute');
+  },
+});
+
+Route.extend({
+  afterModel(posts: Posts, transition: Ember.Transition) {
+    if (posts.length === 1) {
+    //   this.transitionTo('post.show', posts.get('firstObject'));
+    }
+  },
+});
+
+Route.extend({
+  actions: {
+    showModal(evt: {modalName: string}) {
+      this.render(evt.modalName, {
+        outlet: 'modal',
+        into: 'application',
+      });
+    },
+    hideModal(evt: {modalName: string}) {
+      this.disconnectOutlet({
+        outlet: 'modal',
+        parentView: 'application',
+      });
+    },
+  },
+});
+
+Ember.Route.extend({
+  model() {
+    let post = this.modelFor('post');
+    return post.get('comments');
+  },
+});
+
+Route.extend({
+  queryParams: {
+    memberQp: { refreshModel: true },
+  },
+});
+
+Route.extend({
+  renderTemplate() {
+    this.render('photos', {
+      into: 'application',
+      outlet: 'anOutletName',
+    });
+  },
+});
+
+Route.extend({
+  renderTemplate(controller: Ember.Controller, model: {}) {
+    this.render('posts', {
+      // the template to render, referenced by name
+      into: 'application', // the template to render into, referenced by name
+      outlet: 'anOutletName', // the outlet inside `options.into` to render into.
+      controller: 'someControllerName', // the controller to use for this template, referenced by name
+      model: model, // the model to set on `options.controller`.
+    });
+  },
+});
+
+Route.extend({
+  resetController(controller: Ember.Controller, isExiting: boolean, transition: boolean) {
+    if (isExiting) {
+    //   controller.set('page', 1);
+    }
+  },
+});
+
+Route.extend({
+  model() {
+    return this.store.findAll('photo');
+  },
+
+  setupController(controller: Ember.Controller, model: {}) {
+    this._super(controller, model);
+    // this.controllerFor('application').set('showingPhotos', true);
+  },
+});

--- a/types/ember/test/route.ts
+++ b/types/ember/test/route.ts
@@ -3,7 +3,7 @@ import Object from '@ember/object';
 import Array from '@ember/array';
 import Ember from 'ember'; // currently needed for Transition
 
-interface Post extends Object {}
+interface Post extends Ember.Object {}
 
 interface Posts extends Array<Post> {}
 
@@ -40,8 +40,7 @@ Route.extend({
 
 Ember.Route.extend({
   model() {
-    let post = this.modelFor('post');
-    return post.get('comments');
+    return this.modelFor('post');
   },
 });
 
@@ -81,12 +80,8 @@ Route.extend({
 });
 
 Route.extend({
-  model() {
-    return this.store.findAll('photo');
-  },
-
   setupController(controller: Ember.Controller, model: {}) {
     this._super(controller, model);
-    // this.controllerFor('application').set('showingPhotos', true);
+    this.controllerFor('application').set('model', model);
   },
 });

--- a/types/ember/test/route.ts
+++ b/types/ember/test/route.ts
@@ -1,14 +1,11 @@
 import Route from '@ember/routing/route';
 import Object from '@ember/object';
 import Array from '@ember/array';
-import Ember from 'ember'; // Transition isn't currently exposed
+import Ember from 'ember'; // currently needed for Transition
 
 interface Post extends Object {}
 
-interface Posts extends Array<Post> {
-    length: number;
-    firstObject: Post;
-}
+interface Posts extends Array<Post> {}
 
 Route.extend({
   beforeModel(transition: Ember.Transition) {
@@ -19,7 +16,7 @@ Route.extend({
 Route.extend({
   afterModel(posts: Posts, transition: Ember.Transition) {
     if (posts.length === 1) {
-    //   this.transitionTo('post.show', posts.get('firstObject'));
+      this.transitionTo('post.show', posts.firstObject);
     }
   },
 });
@@ -66,7 +63,7 @@ Route.extend({
 Route.extend({
   renderTemplate(controller: Ember.Controller, model: {}) {
     this.render('posts', {
-      // the template to render, referenced by name
+      view: 'someView', // the template to render, referenced by name
       into: 'application', // the template to render into, referenced by name
       outlet: 'anOutletName', // the outlet inside `options.into` to render into.
       controller: 'someControllerName', // the controller to use for this template, referenced by name

--- a/types/ember/test/route.ts
+++ b/types/ember/test/route.ts
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import Ember from 'ember';
+const { Logger } = Ember;
+
+class Route1 extends Route {
+  queryParams = {
+    category: {
+      refreshModel: true,
+    },
+  };
+  templateName: 'posts/favorite-posts';
+}

--- a/types/ember/test/route.ts
+++ b/types/ember/test/route.ts
@@ -70,7 +70,7 @@ Route.extend({
       into: 'application', // the template to render into, referenced by name
       outlet: 'anOutletName', // the outlet inside `options.into` to render into.
       controller: 'someControllerName', // the controller to use for this template, referenced by name
-      model: model, // the model to set on `options.controller`.
+      model, // the model to set on `options.controller`.
     });
   },
 });

--- a/types/ember/tsconfig.json
+++ b/types/ember/tsconfig.json
@@ -38,6 +38,8 @@
         "test/utils.ts",
         "test/transition.ts",
         "test/router.ts",
-        "test/run.ts"
+        "test/run.ts",
+        "test/controller.ts",
+        "test/route.ts"
     ]
 }


### PR DESCRIPTION
- [x] Add Component class properties, methods, and events
- [x] Refactor CoreView to be a private class with correct extends
- [x] Move private Component 'uses' outside exported namespace
- [x] Add Component tests and comments from Ember API docs
- [x] Uses the same pattern to get Controller and Route exporting local and inherited public properties and methods

1. General approach here was to use the `extends` and `uses` sections from the 2.14 api docs for structure:
![image](https://user-images.githubusercontent.com/2126689/31046964-be1c9430-a5c7-11e7-86cd-a27ab973cb63.png)
became
```class Component extends CoreView.extend(ViewMixin, ActionSupport, ClassNamesSupport) {...}```
Note - api labeled private has not been included, but that includes `TargetActionSupport#triggerAction` which doesn't really seem private so much as 'not recommended'. :man_shrugging: 
2. I have NOT checked them against 2.15.
3. I added private classes and mixins outside the Ember namespace as interfaces with matching values (e.g. `const ActionHandler: Ember.Mixin<ActionHandler>`) where needed.
4. Unfortunately, the scope of this PR grew a bit bigger than I'd hoped, including removing a couple of unused namespaces. Happy to move those changes to another PR if it's a problem.