### PR TITLE
Fix `Object.extend` arguments not being type-checked

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -211,25 +211,35 @@ type CreateWithMixins = <Instance extends M1Base, M1, M1Base, Extensions extends
     args?: Extensions & ThisType<Extensions & Instance & M1>)
     => Extensions & Instance & M1;
 
-type Extend1 = <Instance extends B1, Args extends EmberClassArguments<Instance>, T1 extends Args, B1>(
+type Extend1 = <Instance extends B1,
+    T1 extends EmberClassArguments<Instance>, B1>(
     this: new () => Instance,
     arg1?: MixinOrLiteral<T1, B1> & ThisType<Instance & T1>)
     => EmberClassConstructor<T1 & Instance>;
 
-type Extend2 = <Instance extends B1 & B2, Args extends EmberClassArguments<Instance>, T1 extends Args, B1, T2 extends Args, B2>(
+type Extend2 = <Instance extends B1 & B2,
+    T1 extends EmberClassArguments<Instance>, B1,
+    T2 extends EmberClassArguments<Instance>, B2>(
     this: new () => Instance,
     arg1: MixinOrLiteral<T1, B1> & ThisType<Instance & T1>,
     arg2: MixinOrLiteral<T2, B2> & ThisType<Instance & T1 & T2>)
     => EmberClassConstructor<T1 & T2 & Instance>;
 
-type Extend3 = <Instance extends B1 & B2 & B3, Args extends EmberClassArguments<Instance>, T1 extends Args, B1, T2 extends Args, B2, T3 extends Args, B3>(
+type Extend3 = <Instance extends B1 & B2 & B3,
+    T1 extends EmberClassArguments<Instance>, B1,
+    T2 extends EmberClassArguments<Instance>, B2,
+    T3 extends EmberClassArguments<Instance>, B3>(
     this: new () => Instance,
     arg1: MixinOrLiteral<T1, B1> & ThisType<Instance & T1>,
     arg2: MixinOrLiteral<T2, B2> & ThisType<Instance & T1 & T2>,
     arg3: MixinOrLiteral<T3, B3> & ThisType<Instance & T1 & T2 & T3>)
     => EmberClassConstructor<T1 & T2 & T3 & Instance>;
 
-type Extend4 = <Instance extends B1 & B2 & B3 & B4, Args extends EmberClassArguments<Instance>, T1 extends Args, B1, T2 extends Args, B2, T3 extends Args, B3, T4 extends Args, B4>(
+type Extend4 = <Instance extends B1 & B2 & B3 & B4,
+    T1 extends EmberClassArguments<Instance>, B1,
+    T2 extends EmberClassArguments<Instance>, B2,
+    T3 extends EmberClassArguments<Instance>, B3,
+    T4 extends EmberClassArguments<Instance>, B4>(
     this: new () => Instance,
     arg1: MixinOrLiteral<T1, B1> & ThisType<Instance & T1>,
     arg2: MixinOrLiteral<T2, B2> & ThisType<Instance & T1 & T2>,
@@ -925,6 +935,11 @@ namespace Ember {
         static create(): MapWithDefault;
     }
     class Mixin<T, Base = Ember.Object> {
+        /**
+         * Mixin needs to have *something* on its prototype, otherwise it's treated like an empty interface.
+         */
+        __ember_mixin__: never;
+
         static create<T, Base = Ember.Object>(args?: T & ThisType<T & Base>): Mixin<T, Base>;
     }
     interface MutableArray extends Array, MutableEnumberable {

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -211,32 +211,33 @@ type CreateWithMixins = <Instance extends M1Base, M1, M1Base, Extensions extends
     args?: Extensions & ThisType<Extensions & Instance & M1>)
     => Extensions & Instance & M1;
 
-type Extend =
-    (<Instance extends B1, Args extends EmberClassArguments<Instance>, T1 extends Args, B1>(
-        this: new () => Instance,
-        arg1?: MixinOrLiteral<T1, B1> & ThisType<Instance & T1>)
-        => EmberClassConstructor<T1 & Instance>)
-    &
-    (<Instance extends B1 & B2, Args extends EmberClassArguments<Instance>, T1 extends Args, B1, T2 extends Args, B2>(
-        this: new () => Instance,
-        arg1: MixinOrLiteral<T1, B1> & ThisType<Instance & T1>,
-        arg2: MixinOrLiteral<T2, B2> & ThisType<Instance & T1 & T2>)
-        => EmberClassConstructor<T1 & T2 & Instance>)
-    &
-    (<Instance extends B1 & B2 & B3, Args extends EmberClassArguments<Instance>, T1 extends Args, B1, T2 extends Args, B2, T3 extends Args, B3>(
-        this: new () => Instance,
-        arg1: MixinOrLiteral<T1, B1> & ThisType<Instance & T1>,
-        arg2: MixinOrLiteral<T2, B2> & ThisType<Instance & T1 & T2>,
-        arg3: MixinOrLiteral<T3, B3> & ThisType<Instance & T1 & T2 & T3>)
-        => EmberClassConstructor<T1 & T2 & T3 & Instance>)
-    &
-    (<Instance extends B1 & B2 & B3 & B4, Args extends EmberClassArguments<Instance>, T1 extends Args, B1, T2 extends Args, B2, T3 extends Args, B3, T4 extends Args, B4>(
-        this: new () => Instance,
-        arg1: MixinOrLiteral<T1, B1> & ThisType<Instance & T1>,
-        arg2: MixinOrLiteral<T2, B2> & ThisType<Instance & T1 & T2>,
-        arg3: MixinOrLiteral<T3, B3> & ThisType<Instance & T1 & T2 & T3>,
-        arg4: MixinOrLiteral<T4, B4> & ThisType<Instance & T1 & T2 & T3 & T4>)
-        => EmberClassConstructor<T1 & T2 & T3 & T4 & Instance>);
+type Extend1 = <Instance extends B1, Args extends EmberClassArguments<Instance>, T1 extends Args, B1>(
+    this: new () => Instance,
+    arg1?: MixinOrLiteral<T1, B1> & ThisType<Instance & T1>)
+    => EmberClassConstructor<T1 & Instance>;
+
+type Extend2 = <Instance extends B1 & B2, Args extends EmberClassArguments<Instance>, T1 extends Args, B1, T2 extends Args, B2>(
+    this: new () => Instance,
+    arg1: MixinOrLiteral<T1, B1> & ThisType<Instance & T1>,
+    arg2: MixinOrLiteral<T2, B2> & ThisType<Instance & T1 & T2>)
+    => EmberClassConstructor<T1 & T2 & Instance>;
+
+type Extend3 = <Instance extends B1 & B2 & B3, Args extends EmberClassArguments<Instance>, T1 extends Args, B1, T2 extends Args, B2, T3 extends Args, B3>(
+    this: new () => Instance,
+    arg1: MixinOrLiteral<T1, B1> & ThisType<Instance & T1>,
+    arg2: MixinOrLiteral<T2, B2> & ThisType<Instance & T1 & T2>,
+    arg3: MixinOrLiteral<T3, B3> & ThisType<Instance & T1 & T2 & T3>)
+    => EmberClassConstructor<T1 & T2 & T3 & Instance>;
+
+type Extend4 = <Instance extends B1 & B2 & B3 & B4, Args extends EmberClassArguments<Instance>, T1 extends Args, B1, T2 extends Args, B2, T3 extends Args, B3, T4 extends Args, B4>(
+    this: new () => Instance,
+    arg1: MixinOrLiteral<T1, B1> & ThisType<Instance & T1>,
+    arg2: MixinOrLiteral<T2, B2> & ThisType<Instance & T1 & T2>,
+    arg3: MixinOrLiteral<T3, B3> & ThisType<Instance & T1 & T2 & T3>,
+    arg4: MixinOrLiteral<T4, B4> & ThisType<Instance & T1 & T2 & T3 & T4>)
+    => EmberClassConstructor<T1 & T2 & T3 & T4 & Instance>;
+
+type Extend = Extend1 & Extend2 & Extend3 & Extend4;
 
 type Reopen = <Instance, Extra>(
     this: new () => Instance,

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -211,10 +211,12 @@ type CreateWithMixins = <Instance extends M1Base, M1, M1Base, Extensions extends
     args?: Extensions & ThisType<Extensions & Instance & M1>)
     => Extensions & Instance & M1;
 
+type Extend0 = <Instance>(this: new () => Instance) => EmberClassConstructor<Instance>;
+
 type Extend1 = <Instance extends B1,
     T1 extends EmberClassArguments<Instance>, B1>(
     this: new () => Instance,
-    arg1?: MixinOrLiteral<T1, B1> & ThisType<Instance & T1>)
+    arg1: MixinOrLiteral<T1, B1> & ThisType<Instance & T1>)
     => EmberClassConstructor<T1 & Instance>;
 
 type Extend2 = <Instance extends B1 & B2,
@@ -247,7 +249,7 @@ type Extend4 = <Instance extends B1 & B2 & B3 & B4,
     arg4: MixinOrLiteral<T4, B4> & ThisType<Instance & T1 & T2 & T3 & T4>)
     => EmberClassConstructor<T1 & T2 & T3 & T4 & Instance>;
 
-type Extend = Extend1 & Extend2 & Extend3 & Extend4;
+type Extend = Extend0 & Extend1 & Extend2 & Extend3 & Extend4;
 
 type Reopen = <Instance, Extra>(
     this: new () => Instance,

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -938,7 +938,7 @@ namespace Ember {
         /**
          * Mixin needs to have *something* on its prototype, otherwise it's treated like an empty interface.
          */
-        __ember_mixin__: never;
+        private __ember_mixin__: never;
 
         static create<T, Base = Ember.Object>(args?: T & ThisType<T & Base>): Mixin<T, Base>;
     }


### PR DESCRIPTION
/cc @dfreeman 

This is something I noticed after merging #11. `extend` lets you pass any argument, even if the types don't match the definition:
```js
// given that Controller is defined like...
class Controller extends Object {
    needs: string[];
}

class X extends Controller {
    needs: 42 // error: types not compatible
}

Controller.extend({
    needs: 42 // this PR makes this an error again
});
```

It was caused by `MixinOrLiteral`:
```
type MixinOrLiteral<T, Base> = Ember.Mixin<T, Base> | T;
```
Since `Ember.Mixin` had nothing on its prototype, every `extend` invocation matches the first case.

I don't think I can write a test for it because we would be checking that the code _doesn't_ compile.