### PR TITLE
Add a type parameter to Enumerable and friends

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -461,7 +461,8 @@ namespace Ember {
     forwarding all requests. This makes it very useful for a number of binding use cases or other cases
     where being able to swap out the underlying array is useful.
     **/
-    class ArrayProxy<T> extends Object.extend(MutableArray as Mixin<MutableArray<T>>) {
+    interface ArrayProxy<T> extends MutableArray<T> {}
+    class ArrayProxy<T> extends Object.extend(MutableArray as {}) {
         content: Ember.Array<T>;
         objectAtContent(idx: number): any;
         replaceContent(idx: number, amt: number, objects: any[]): void;

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -281,14 +281,14 @@ interface EnumerableConfigurationOptions {
     didChange?: boolean;
 }
 
-type ItemIndexEnumerableCallback = (item: any, index: number, enumerable: Ember.Enumerable) => void;
+type ItemIndexEnumerableCallback<T, U, This> = (item: T, index: number, enumerable: This) => U;
 
-type ReduceCallback = (
-    previousValue: any,
-    item: any,
+type ReduceCallback<T, U, This> = (
+    previousValue: U,
+    item: T,
     index: number,
-    enumerable: Ember.Enumerable
-) => void;
+    enumerable: This
+) => U;
 
 interface TransitionsHash {
     contexts: any[];
@@ -327,7 +327,7 @@ namespace Ember {
     recommended that you use Ember.A when creating addons for ember or when you can not garentee
     that Ember.EXTEND_PROTOTYPES will be true.
     **/
-    function A(arr?: any[]): NativeArray;
+    function A<T>(arr?: T[]): NativeArray<T>;
     /**
     The Ember.ActionHandler mixin implements support for moving an actions property to an _actions
     property at extend time, and adding _actions to the object's mergedProperties list.
@@ -440,27 +440,29 @@ namespace Ember {
     This module implements Observer-friendly Array-like behavior. This mixin is picked up by the
     Array class as well as other controllers, etc. that want to appear to be arrays.
     **/
-    interface Array extends Enumerable {
-        addArrayObserver(target: any, opts?: EnumerableConfigurationOptions): any[];
-        arrayContentDidChange(startIdx: number, removeAmt: number, addAmt: number): any[];
-        arrayContentWillChange(startIdx: number, removeAmt: number, addAmt: number): any[];
-        indexOf(object: any, startAt: number): number;
-        lastIndexOf(object: any, startAt: number): number;
-        objectAt(idx: number): any;
-        objectsAt(...args: number[]): any[];
-        removeArrayObserver(target: any, opts: EnumerableConfigurationOptions): any[];
-        slice(beginIndex?: number, endIndex?: number): any[];
+    interface Array<T> extends Enumerable<T> {
+        addArrayObserver(target: any, opts?: EnumerableConfigurationOptions): this;
+        arrayContentDidChange(startIdx: number, removeAmt: number, addAmt: number): this;
+        arrayContentWillChange(startIdx: number, removeAmt: number, addAmt: number): this;
+        indexOf(object: T, startAt?: number): number;
+        lastIndexOf(object: T, startAt?: number): number;
+        objectAt(idx: number): T;
+        objectsAt(...args: number[]): T[];
+        removeArrayObserver(target: any, opts: EnumerableConfigurationOptions): this;
+        slice(beginIndex?: number, endIndex?: number): T[];
         '@each': EachProxy;
         length: number;
     }
-    const Array: Mixin<Ember.Array>;
+    // Ember.Array rather than Array because the `array-type` lint rule doesn't realize the global is shadowed
+    const Array: Mixin<Ember.Array<any>>;
+
     /**
     An ArrayProxy wraps any other object that implements Ember.Array and/or Ember.MutableArray,
     forwarding all requests. This makes it very useful for a number of binding use cases or other cases
     where being able to swap out the underlying array is useful.
     **/
-    class ArrayProxy extends Object.extend(MutableArray) {
-        content: NativeArray;
+    class ArrayProxy<T> extends Object.extend(MutableArray as Mixin<MutableArray<T>>) {
+        content: Ember.Array<T>;
         objectAtContent(idx: number): any;
         replaceContent(idx: number, amt: number, objects: any[]): void;
     }
@@ -760,53 +762,54 @@ namespace Ember {
     This mixin is applied automatically to the Array class on page load, so you can use any of these methods
     on simple arrays. If Array already implements one of these methods, the mixin will not override them.
     **/
-    interface Enumerable {
-        addEnumerableObserver(target: any, opts: EnumerableConfigurationOptions): Enumerable;
-        any(callback: ItemIndexEnumerableCallback, target?: any): boolean;
+    interface Enumerable<T> {
+        addEnumerableObserver(target: any, opts: EnumerableConfigurationOptions): this;
+        any(callback: ItemIndexEnumerableCallback<T, boolean, this>, target?: any): boolean;
         anyBy(key: string, value?: string): boolean;
         isAny(key: string, value?: boolean): boolean;
         someProperty(key: string, value?: string): boolean;
-        compact(): any[];
-        contains(obj: any): boolean;
+        compact(): T[];
+        contains(obj: T): boolean;
         enumerableContentDidChange(
             start: number,
-            removing: Enumerable | number,
-            adding: Enumerable | number
-        ): any;
-        enumerableContentDidChange(removing: Enumerable | number, adding: Enumerable | number): any;
+            removing: Enumerable<T> | number,
+            adding: Enumerable<T> | number
+        ): this;
+        enumerableContentDidChange(removing: Enumerable<T> | number, adding: Enumerable<T> | number): this;
         enumerableContentWillChange(
-            removing: Enumerable | number,
-            adding: Enumerable | number
-        ): Enumerable;
-        every(callback: ItemIndexEnumerableCallback, target?: any): boolean;
+            removing: Enumerable<T> | number,
+            adding: Enumerable<T> | number
+        ): this;
+        every(callback: ItemIndexEnumerableCallback<T, boolean, this>, target?: any): boolean;
         isEvery(key: string, value?: boolean): boolean;
         everyBy(key: string, value?: string): boolean;
         everyProperty(key: string, value?: string): boolean;
-        filter(callback: ItemIndexEnumerableCallback, target: any): any[];
-        filterBy(key: string, value?: string): any[];
-        find(callback: ItemIndexEnumerableCallback, target: any): any;
-        findBy(key: string, value?: string): any;
-        forEach(callback: ItemIndexEnumerableCallback, target?: any): any;
+        filter(callback: ItemIndexEnumerableCallback<T, boolean, this>, target: any): T[];
+        filterBy(key: string, value?: string): T[];
+        find(callback: ItemIndexEnumerableCallback<T, boolean, this>, target: any): T | undefined;
+        findBy(key: string, value?: string): T | undefined;
+        forEach(callback: ItemIndexEnumerableCallback<T, void, this>, target?: any): void;
         getEach(key: string): any[];
         invoke(methodName: string, ...args: any[]): any[];
-        map(callback: ItemIndexEnumerableCallback, target?: any): any[];
+        map<U>(callback: ItemIndexEnumerableCallback<T, U, this>, target?: any): U[];
+        mapBy<K extends keyof T>(key: K): GlobalArray<T[K]>;
         mapBy(key: string): any[];
-        nextObject(index: number, previousObject: any, context: any): any;
-        reduce(callback: ReduceCallback, initialValue: any, reducerProperty: string): any;
-        reject(callback: ItemIndexEnumerableCallback, target?: any): any[];
-        rejectBy(key: string, value?: string): any[];
-        removeEnumerableObserver(target: any, opts: EnumerableConfigurationOptions): Enumerable;
-        setEach(key: string, value?: any): any;
-        some(callback: ItemIndexEnumerableCallback, target?: any): boolean;
-        toArray(): any[];
-        uniq(): Enumerable;
-        without(value: any): Enumerable;
-        '[]': any[];
-        firstObject: any;
+        nextObject(index: number, previousObject: T, context: any): T | undefined;
+        reduce<U>(callback: ReduceCallback<T, U, this>, initialValue: U, reducerProperty: string): U;
+        reject(callback: ItemIndexEnumerableCallback<T, boolean, this>, target?: any): T[];
+        rejectBy(key: string, value?: string): T[];
+        removeEnumerableObserver(target: any, opts: EnumerableConfigurationOptions): this;
+        setEach(key: string, value?: any): this;
+        some(callback: ItemIndexEnumerableCallback<T, boolean, this>, target?: any): boolean;
+        toArray(): T[];
+        uniq(): Enumerable<T>;
+        without(value: T): Enumerable<T>;
+        '[]': T[];
+        firstObject: T;
         hasEnumerableObservers: boolean;
-        lastObject: any;
+        lastObject: T;
     }
-    const Enumerable: Mixin<Enumerable>;
+    const Enumerable: Mixin<Enumerable<any>>;
     /**
     A subclass of the JavaScript Error object for use in Ember.
     **/
@@ -926,34 +929,34 @@ namespace Ember {
     class Mixin<T, Base = Ember.Object> {
         static create<T, Base = Ember.Object>(args?: T & ThisType<T & Base>): Mixin<T, Base>;
     }
-    interface MutableArray extends Array, MutableEnumberable {
-        clear(): any[];
-        insertAt(idx: number, object: any): any[];
-        popObject(): any;
-        pushObject(obj: any): any;
-        pushObjects(...args: any[]): any[];
-        removeAt(start: number, len: number): any;
-        replace(idx: number, amt: number, objects: any[]): any;
-        reverseObjects(): any[];
-        setObjects(objects: any[]): any[];
-        shiftObject(): any;
-        unshiftObject(object: any): any;
-        unshiftObjects(objects: any[]): any[];
+    interface MutableArray<T> extends Array<T>, MutableEnumberable<T> {
+        clear(): this;
+        insertAt(idx: number, object: T): this;
+        popObject(): T;
+        pushObject(obj: T): T;
+        pushObjects(...args: T[]): this;
+        removeAt(start: number, len: number): this;
+        replace(idx: number, amt: number, objects: T[]): this;
+        reverseObjects(): this;
+        setObjects(objects: T[]): this;
+        shiftObject(): T;
+        unshiftObject(object: T): T;
+        unshiftObjects(objects: T[]): this;
     }
-    const MutableArray: Mixin<MutableArray>;
-    interface MutableEnumberable extends Enumerable {
-        addObject(object: any): any;
-        addObjects(objects: Enumerable): MutableEnumberable;
-        removeObject(object: any): any;
-        removeObjects(objects: Enumerable): MutableEnumberable;
+    const MutableArray: Mixin<MutableArray<any>>;
+    interface MutableEnumberable<T> extends Enumerable<T> {
+        addObject(object: T): T;
+        addObjects(objects: Enumerable<T>): this;
+        removeObject(object: T): T;
+        removeObjects(objects: Enumerable<T>): this;
     }
-    const MutableEnumerable: Mixin<MutableEnumberable>;
+    const MutableEnumerable: Mixin<MutableEnumberable<any>>;
     const NAME_KEY: string;
     class Namespace extends Object {
     }
-    interface NativeArray extends MutableArray, Observable, Copyable {
+    interface NativeArray<T> extends MutableArray<T>, Observable, Copyable {
     }
-    const NativeArray: Mixin<NativeArray>;
+    const NativeArray: Mixin<NativeArray<any>>;
     class NoneLocation extends Object {
     }
     const ORDER_DEFINITION: string[];

--- a/types/ember/test/array-proxy.ts
+++ b/types/ember/test/array-proxy.ts
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { assertType } from './lib/assert';
 
 const pets = ['dog', 'cat', 'fish'];
 const proxy = Ember.ArrayProxy.create({ content: Ember.A(pets) });
@@ -15,3 +16,11 @@ const overridden = Ember.ArrayProxy.create({
 });
 
 overridden.get('firstObject'); // 'DOG'
+
+class MyNewProxy<T> extends Ember.ArrayProxy<T> {
+    isNew = true;
+}
+
+let x: MyNewProxy<number> = MyNewProxy.create({ content: Ember.A([1, 2, 3]) });
+assertType<number>(x.get('firstObject'));
+assertType<boolean>(x.isNew);

--- a/types/ember/test/array.ts
+++ b/types/ember/test/array.ts
@@ -16,3 +16,17 @@ people.get('lastObject');
 people.isAny('isHappy');
 people.isAny('isHappy', false);
 people.filterBy('isHappy');
+
+assertType<boolean[]>(people.mapBy('isHappy'));
+assertType<any[]>(people.mapBy('name.length'));
+
+assertType<string>(people.get('lastObject').get('name'));
+assertType<boolean>(people.get('firstObject').get('isHappy'));
+
+const letters: Ember.Enumerable<string> = Ember.A(['a', 'b', 'c']);
+const codes: number[] = letters.map((item, index, enumerable) => {
+    assertType<string>(item);
+    assertType<number>(index);
+    assertType<Ember.Enumerable<string>>(enumerable);
+    return item.charCodeAt(0);
+});


### PR DESCRIPTION
This change makes `Ember.Enumerable` and its descendants polymorphic, allowing for better type safety in their properties and methods.