### PR TITLE
allow computed properties without set

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1704,7 +1704,7 @@ namespace Ember {
 
     interface ComputedPropertyGetSet<T> {
         get(this: any, key: string): T;
-        set(this: any, key: string, value: T): T;
+        set?(this: any, key: string, value: T): T;
     }
 
     type ComputedPropertyFunction<T> = ComputedPropertyGet<T> | ComputedPropertyGetSet<T>;

--- a/types/ember/test/computed.ts
+++ b/types/ember/test/computed.ts
@@ -26,6 +26,12 @@ const Person = Ember.Object.extend({
             this.ste('lastName', last);
             return value;
         }
+    }),
+
+    fullNameGetOnly: Ember.computed('fullName', {
+        get() {
+            return this.get('fullName');
+        }
     })
 });
 
@@ -40,4 +46,5 @@ assertType<string>(person.get('firstName'));
 assertType<string>(person.get('fullName'));
 assertType<string>(person.get('fullNameReadonly'));
 assertType<string>(person.get('fullNameWritable'));
+assertType<string>(person.get('fullNameGetOnly'));
 assertType<{ firstName: string, fullName: string, age: number }>(person.getProperties('firstName', 'fullName', 'age'));


### PR DESCRIPTION
This allows CPs without a setter, like the following:

```js
    fullNameGetOnly: Ember.computed('fullName', {
        get() {
            return this.get('fullName');
        }
    })
```