### PR TITLE
Allow for set-only CPs

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1700,24 +1700,32 @@ namespace Ember {
     }
     // ReSharper disable once DuplicatingLocalDeclaration
 
-    type ComputedPropertyGet<T> = (this: any, key: string) => T;
+    type ComputedPropertyGetterFunction<T> = (this: any, key: string) => T;
 
-    interface ComputedPropertyGetSet<T> {
+    interface ComputedPropertyGet<T> {
         get(this: any, key: string): T;
-        set?(this: any, key: string, value: T): T;
     }
 
-    type ComputedPropertyFunction<T> = ComputedPropertyGet<T> | ComputedPropertyGetSet<T>;
+    interface ComputedPropertySet<T> {
+        set(this: any, key: string, value: T): T;
+    }
+
+    type ComputedPropertyCallback<T> =
+        ComputedPropertyGetterFunction<T> |
+        ComputedPropertyGet<T> |
+        ComputedPropertySet<T> |
+        (ComputedPropertyGet<T> & ComputedPropertySet<T>);
+
     type ComputedPropertyReturn<T> = ComputedProperty & T;
 
     const computed: {
-        <T>(cb: ComputedPropertyFunction<T>): ComputedPropertyReturn<T>;
-        <T>(k1: string, cb: ComputedPropertyFunction<T>): ComputedPropertyReturn<T>;
-        <T>(k1: string, k2: string, cb: ComputedPropertyFunction<T>): ComputedPropertyReturn<T>;
-        <T>(k1: string, k2: string, k3: string, cb: ComputedPropertyFunction<T>): ComputedPropertyReturn<T>;
-        <T>(k1: string, k2: string, k3: string, k4: string, cb: ComputedPropertyFunction<T>): ComputedPropertyReturn<T>;
-        <T>(k1: string, k2: string, k3: string, k4: string, k5: string, cb: ComputedPropertyFunction<T>): ComputedPropertyReturn<T>;
-        <T>(k1: string, k2: string, k3: string, k4: string, k5: string, k6: string, cb: ComputedPropertyFunction<T>): ComputedPropertyReturn<T>;
+        <T>(cb: ComputedPropertyCallback<T>): ComputedPropertyReturn<T>;
+        <T>(k1: string, cb: ComputedPropertyCallback<T>): ComputedPropertyReturn<T>;
+        <T>(k1: string, k2: string, cb: ComputedPropertyCallback<T>): ComputedPropertyReturn<T>;
+        <T>(k1: string, k2: string, k3: string, cb: ComputedPropertyCallback<T>): ComputedPropertyReturn<T>;
+        <T>(k1: string, k2: string, k3: string, k4: string, cb: ComputedPropertyCallback<T>): ComputedPropertyReturn<T>;
+        <T>(k1: string, k2: string, k3: string, k4: string, k5: string, cb: ComputedPropertyCallback<T>): ComputedPropertyReturn<T>;
+        <T>(k1: string, k2: string, k3: string, k4: string, k5: string, k6: string, cb: ComputedPropertyCallback<T>): ComputedPropertyReturn<T>;
         (k1: string, k2: string, k3: string, k4: string, k5: string, k6: string, k7: string, ...rest: any[]): ComputedProperty;
 
         alias(dependentKey: string): ComputedProperty;

--- a/types/ember/test/computed.ts
+++ b/types/ember/test/computed.ts
@@ -32,6 +32,15 @@ const Person = Ember.Object.extend({
         get() {
             return this.get('fullName');
         }
+    }),
+
+    fullNameSetOnly: Ember.computed('firstName', 'lastName', {
+        set(key, value) {
+            let [first, last] = value.split(' ');
+            this.set('firstName', first);
+            this.ste('lastName', last);
+            return value;
+        }
     })
 });
 
@@ -47,4 +56,5 @@ assertType<string>(person.get('fullName'));
 assertType<string>(person.get('fullNameReadonly'));
 assertType<string>(person.get('fullNameWritable'));
 assertType<string>(person.get('fullNameGetOnly'));
+assertType<string>(person.get('fullNameSetOnly'));
 assertType<{ firstName: string, fullName: string, age: number }>(person.getProperties('firstName', 'fullName', 'age'));

--- a/types/ember/test/computed.ts
+++ b/types/ember/test/computed.ts
@@ -23,7 +23,7 @@ const Person = Ember.Object.extend({
         set(key, value) {
             let [first, last] = value.split(' ');
             this.set('firstName', first);
-            this.ste('lastName', last);
+            this.set('lastName', last);
             return value;
         }
     }),
@@ -38,7 +38,7 @@ const Person = Ember.Object.extend({
         set(key, value) {
             let [first, last] = value.split(' ');
             this.set('firstName', first);
-            this.ste('lastName', last);
+            this.set('lastName', last);
             return value;
         }
     })


### PR DESCRIPTION
On the heels of #27, this allows CPs without get:

```js
    fullNameSetOnly: Ember.computed('firstName', 'lastName', {
        set(key, value) {
            let [first, last] = value.split(' ');
            this.set('firstName', first);
            this.ste('lastName', last);
            return value;
        }
    })
```