### PR TITLE
Update travis-ci to use nodejs 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "8"
 
 sudo: false
 dist: trusty


### PR DESCRIPTION
Our `package.json` specifies `"node": ">=7.8.0"` which is apparently required by DT: DefinitelyTyped/DefinitelyTyped#15564

The CI builds fail since the Yarn 1.0.1 update because travis is still running node 6 and yarn checks this now
```
yarn install v1.0.1
[1/5] Validating package.json...
error ember-typings@0.0.1: The engine "node" is incompatible with this module. Expected version ">=7.8.0".
error Found incompatible module
```