### PR TITLE
Implement typed computed property access

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -299,7 +299,7 @@ export namespace Ember {
          * when `EmberENV.EXTEND_PROTOTYPES` or `EmberENV.EXTEND_PROTOTYPES.Function` is
          * `true`, which is the default.
          */
-        property(...args: string[]): ComputedProperty;
+        property(...args: string[]): ComputedProperty<any>;
         /**
          * The `observes` extension of Javascript's Function prototype is available
          * when `EmberENV.EXTEND_PROTOTYPES` or `EmberENV.EXTEND_PROTOTYPES.Function` is

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -647,8 +647,8 @@ export namespace Ember {
             this: EmberClassConstructor<Instance>
         ): Fix<Instance>;
 
-        static create<Instance, Extensions extends EmberClassArguments<Instance>>(
-            this: EmberClassConstructor<Instance>,
+        static create<Instance, Args, Extensions extends EmberClassArguments<Args>>(
+            this: EmberClassConstructor<Instance & ComputedProperties<Args>>,
             args: Extensions & ThisType<Fix<Extensions & Instance>>
         ): Fix<Instance & Extensions>;
 

--- a/types/ember/test/array.ts
+++ b/types/ember/test/array.ts
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { assertType } from './lib/assert';
 
+type Person = typeof Person.prototype;
 const Person = Ember.Object.extend({
     name: '',
     isHappy: false
@@ -11,11 +12,13 @@ const people = Ember.A([
     Person.create({ name: 'Majd', isHappy: false }),
 ]);
 
-people.get('length');
-people.get('lastObject');
-people.isAny('isHappy');
-people.isAny('isHappy', false);
-people.filterBy('isHappy');
+assertType<number>(people.get('length'));
+assertType<Person>(people.get('lastObject'));
+assertType<boolean>(people.isAny('isHappy'));
+assertType<boolean>(people.isAny('isHappy', false));
+assertType<Person[]>(people.filterBy('isHappy'));
+assertType<typeof people>(people.get('[]'));
+assertType<Person>(people.get('[]').get('firstObject'));
 
 assertType<boolean[]>(people.mapBy('isHappy'));
 assertType<any[]>(people.mapBy('name.length'));

--- a/types/ember/test/computed.ts
+++ b/types/ember/test/computed.ts
@@ -78,3 +78,9 @@ assertType<string>(person.get('fullNameSetOnly'));
 assertType<string>(person.get('combinators'));
 
 assertType<{ firstName: string, fullName: string, age: number }>(person.getProperties('firstName', 'fullName', 'age'));
+
+const person2 = Person.create({
+    fullName: 'Fred Smith'
+});
+
+assertType<string>(person2.get('fullName'));

--- a/types/ember/test/computed.ts
+++ b/types/ember/test/computed.ts
@@ -6,17 +6,17 @@ const Person = Ember.Object.extend({
     lastName: '',
     age: 0,
 
-    noArgs: Ember.computed(() => 'test'),
+    noArgs: Ember.computed<string>(() => 'test'),
 
-    fullName: Ember.computed('firstName', 'lastName', function() {
+    fullName: Ember.computed<string>('firstName', 'lastName', function() {
         return `${this.get('firstName')} ${this.get('lastName')}`;
     }),
 
-    fullNameReadonly: Ember.computed('fullName', function() {
+    fullNameReadonly: Ember.computed<string>('fullName', function() {
         return this.get('fullName');
     }).readOnly(),
 
-    fullNameWritable: Ember.computed('firstName', 'lastName', {
+    fullNameWritable: Ember.computed<string>('firstName', 'lastName', {
         get() {
             return this.get('fullName');
         },
@@ -28,20 +28,27 @@ const Person = Ember.Object.extend({
         }
     }),
 
-    fullNameGetOnly: Ember.computed('fullName', {
+    fullNameGetOnly: Ember.computed<string>('fullName', {
         get() {
             return this.get('fullName');
         }
     }),
 
-    fullNameSetOnly: Ember.computed('firstName', 'lastName', {
+    fullNameSetOnly: Ember.computed<string>('firstName', 'lastName', {
         set(key, value) {
             let [first, last] = value.split(' ');
             this.set('firstName', first);
             this.set('lastName', last);
             return value;
         }
-    })
+    }),
+
+    combinators: Ember.computed<string>(function() {
+        return this.get('firstName');
+    }).property('firstName')
+      .meta({ foo: 'bar' })
+      .volatile()
+      .readOnly()
 });
 
 const person = Person.create({
@@ -50,11 +57,24 @@ const person = Person.create({
     age: 29,
 });
 
-assertType<string>(person.get('noArgs'));
+assertType<string>(person.firstName);
+assertType<number>(person.age);
+assertType<Ember.ComputedProperty<string>>(person.noArgs);
+assertType<Ember.ComputedProperty<string>>(person.fullName);
+assertType<Ember.ComputedProperty<string>>(person.fullNameReadonly);
+assertType<Ember.ComputedProperty<string>>(person.fullNameWritable);
+assertType<Ember.ComputedProperty<string>>(person.fullNameGetOnly);
+assertType<Ember.ComputedProperty<string>>(person.fullNameSetOnly);
+assertType<Ember.ComputedProperty<string>>(person.combinators);
+
 assertType<string>(person.get('firstName'));
+assertType<number>(person.get('age'));
+assertType<string>(person.get('noArgs'));
 assertType<string>(person.get('fullName'));
 assertType<string>(person.get('fullNameReadonly'));
 assertType<string>(person.get('fullNameWritable'));
 assertType<string>(person.get('fullNameGetOnly'));
 assertType<string>(person.get('fullNameSetOnly'));
+assertType<string>(person.get('combinators'));
+
 assertType<{ firstName: string, fullName: string, age: number }>(person.getProperties('firstName', 'fullName', 'age'));

--- a/types/ember/test/extend.ts
+++ b/types/ember/test/extend.ts
@@ -5,7 +5,12 @@ const Person = Ember.Object.extend({
     firstName: '',
     lastName: '',
 
-    getFullName() { return `${this.firstName} ${this.lastName}`; }
+    getFullName() {
+        return `${this.firstName} ${this.lastName}`;
+    },
+    getFullName2(): string {
+        return `${this.get('firstName')} ${this.get('lastName')}`;
+    }
 });
 
 assertType<string>(Person.prototype.firstName);
@@ -24,7 +29,12 @@ class ES6Person extends Ember.Object {
     firstName: string;
     lastName: string;
 
-    get fullName() { return `${this.firstName} ${this.lastName}`; }
+    get fullName() {
+        return `${this.firstName} ${this.lastName}`;
+    }
+    get fullName2(): string {
+        return `${this.get('firstName')} ${this.get('lastName')}`;
+    }
 }
 
 assertType<string>(ES6Person.prototype.firstName);

--- a/types/ember/test/get-properties.ts
+++ b/types/ember/test/get-properties.ts
@@ -4,15 +4,20 @@ import { assertType } from './lib/assert';
 const person = Ember.Object.create({
     name: 'Fred',
     age: 29,
+    capitalized: Ember.computed<string>(function() {
+        return this.get('name').toUpperCase();
+    })
 });
 
 assertType<{ name: string }>(Ember.getProperties(person, 'name'));
 assertType<{ name: string, age: number }>(Ember.getProperties(person, 'name', 'age'));
 assertType<{ name: string, age: number }>(Ember.getProperties(person, [ 'name', 'age' ]));
+assertType<{ name: string, age: number, capitalized: string }>(Ember.getProperties(person, 'name', 'age', 'capitalized'));
 
 assertType<{ name: string }>(person.getProperties('name'));
 assertType<{ name: string, age: number }>(person.getProperties('name', 'age'));
 assertType<{ name: string, age: number }>(person.getProperties([ 'name', 'age' ]));
+assertType<{ name: string, age: number, capitalized: string }>(person.getProperties('name', 'age', 'capitalized'));
 
 const pojo = { name: 'Fred', age: 29 };
 assertType<{ name: string, age: number }>(Ember.getProperties(pojo, 'name', 'age'));

--- a/types/ember/test/get.ts
+++ b/types/ember/test/get.ts
@@ -4,13 +4,18 @@ import { assertType } from './lib/assert';
 const person = Ember.Object.create({
     name: 'Fred',
     age: 29,
+    capitalized: Ember.computed<string>(function() {
+        return this.get('name').toUpperCase();
+    })
 });
 
 assertType<string>(Ember.get(person, 'name'));
 assertType<number>(Ember.get(person, 'age'));
+assertType<string>(Ember.get(person, 'capitalized'));
 
 assertType<string>(person.get('name'));
 assertType<number>(person.get('age'));
+assertType<string>(person.get('capitalized'));
 
 const pojo = { name: 'Fred' };
 

--- a/types/ember/test/reopen.ts
+++ b/types/ember/test/reopen.ts
@@ -31,3 +31,17 @@ let yehuda = Person2.createPerson('Yehuda Katz');
 tom.sayHello(); // "Hello. My name is Tom Dale"
 yehuda.sayHello(); // "Hello. My name is Yehuda Katz"
 alert(Person2.species); // "Homo sapiens"
+
+const Person3 = Person2.reopen({
+    goodbyeMessage: 'goodbye',
+
+    sayGoodbye() {
+        alert(`${this.get('goodbyeMessage')}, ${this.get('name')}`);
+    }
+});
+
+const person3 = Person3.create();
+person3.get('name');
+person3.get('goodbyeMessage');
+person3.sayHello();
+person3.sayGoodbye();

--- a/types/ember/test/set-properties.ts
+++ b/types/ember/test/set-properties.ts
@@ -4,10 +4,15 @@ import { assertType } from './lib/assert';
 const person = Ember.Object.create({
     name: 'Fred',
     age: 29,
+    capitalized: Ember.computed<string>(function() {
+        return this.get('name').toUpperCase();
+    })
 });
 
 assertType<{ name: string }>(Ember.setProperties(person, { name: 'Joe' }));
 assertType<{ name: string, age: number }>(Ember.setProperties(person, { name: 'Joe', age: 35 }));
+assertType<{ name: string, capitalized: string }>(Ember.setProperties(person, { name: 'Joe', capitalized: 'JOE' }));
 
 assertType<{ name: string }>(person.setProperties({ name: 'Joe' }));
 assertType<{ name: string, age: number }>(person.setProperties({ name: 'Joe', age: 35 }));
+assertType<{ name: string, capitalized: string }>(person.setProperties({ name: 'Joe', capitalized: 'JOE' }));

--- a/types/ember/test/set.ts
+++ b/types/ember/test/set.ts
@@ -4,13 +4,18 @@ import { assertType } from './lib/assert';
 const person = Ember.Object.create({
     name: 'Fred',
     age: 29,
+    capitalized: Ember.computed<string>(function() {
+        return this.get('name').toUpperCase();
+    })
 });
 
 assertType<string>(Ember.set(person, 'name', 'Joe'));
 assertType<number>(Ember.set(person, 'age', 35));
+assertType<string>(Ember.set(person, 'capitalized', 'JOE'));
 
 assertType<string>(person.set('name', 'Joe'));
 assertType<number>(person.set('age', 35));
+assertType<string>(person.set('capitalized', 'JOE'));
 
 const pojo = { name: 'Fred' };
 


### PR DESCRIPTION
So that `obj.computedProperty` correctly returns an `Ember.ComputedProperty` and `obj.get('computedProperty')` returns the actual property type