### PR TITLE
Implement function prototype extensions

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -174,13 +174,6 @@ namespace EmberTesting {
     }
 }
 
-interface Function {
-    observes(...args: string[]): Function;
-    observesBefore(...args: string[]): Function;
-    on(...args: string[]): Function;
-    property(...args: string[]): Function;
-}
-
 interface String {
     camelize(): string;
     capitalize(): string;
@@ -288,6 +281,27 @@ export namespace Ember {
     that Ember.EXTEND_PROTOTYPES will be true.
     **/
     function A<T>(arr?: T[]): NativeArray<T>;
+
+    interface FunctionPrototypeExtensions {
+        /**
+         * The `property` extension of Javascript's Function prototype is available
+         * when `EmberENV.EXTEND_PROTOTYPES` or `EmberENV.EXTEND_PROTOTYPES.Function` is
+         * `true`, which is the default.
+         */
+        property(...args: string[]): ComputedProperty;
+        /**
+         * The `observes` extension of Javascript's Function prototype is available
+         * when `EmberENV.EXTEND_PROTOTYPES` or `EmberENV.EXTEND_PROTOTYPES.Function` is
+         * true, which is the default.
+         */
+        observes(...args: string[]): this;
+        /**
+         * The `on` extension of Javascript's Function prototype is available
+         * when `EmberENV.EXTEND_PROTOTYPES` or `EmberENV.EXTEND_PROTOTYPES.Function` is
+         * true, which is the default.
+         */
+        on(...args: string[]): this;
+    }
     /**
     The Ember.ActionHandler mixin implements support for moving an actions property to an _actions
     property at extend time, and adding _actions to the object's mergedProperties list.

--- a/types/ember/test/function-ext.ts
+++ b/types/ember/test/function-ext.ts
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+
+declare global {
+    interface Function extends Ember.FunctionPrototypeExtensions {}
+}
+
+Ember.Object.extend({
+    foo: '',
+
+    arr: function() {
+        return [];
+    }.property(),
+
+    alias: function(this: any) {
+        return this.get('foo');
+    }.property('foo', 'bar.@each.baz'),
+
+    observer: function() {
+    }.observes('foo', 'bar'),
+
+    on: function() {
+    }.on('foo', 'bar')
+});

--- a/types/ember/tsconfig.json
+++ b/types/ember/tsconfig.json
@@ -30,6 +30,7 @@
         "test/set.ts",
         "test/set-properties.ts",
         "test/computed.ts",
-        "test/component.ts"
+        "test/component.ts",
+        "test/function-ext.ts"
     ]
 }

--- a/types/ember/tslint.json
+++ b/types/ember/tslint.json
@@ -13,6 +13,7 @@
         "no-duplicate-imports": false,
         "no-unnecessary-qualifier": false,
         "prefer-const": false,
-        "no-void-expression": false
+        "no-void-expression": false,
+        "only-arrow-functions": false
     }
 }


### PR DESCRIPTION
We unintentionally re-defined `Function` and shadowed the global definition. Anyone using any API which directly or indirectly references our "Function" will have an error:
> TS4023:Exported variable 'obj' has or is using name 'Function' from external module 'ember' but cannot be named.