### PR TITLE
Some object model cleanup

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -195,11 +195,21 @@ type ComputedProperties<T> = {
 };
 
 /**
- * Check that any arguments to `create()` and `extend()` match the type's properties.
+ * Check that any arguments to `create()` match the type's properties.
  *
+ * Accept any additional properties and add merge them into the instance.
+ */
+type EmberInstanceArguments<T> = Partial<T> & {
+    [key: string]: any
+};
+
+/**
+ * Check that any arguments to `extend()` match the type's properties.
+ *
+ * For any property type `K`, `K` and `ComputedProperty<K>` are both assignable.
  * Accept any additional properties and add merge them into the prototype.
  */
-type EmberClassArguments<T> = Partial<T> & {
+type EmberClassArguments<T> = Partial<ComputedProperties<T>> & {
     [key: string]: any
 };
 
@@ -662,23 +672,23 @@ export namespace Ember {
         ): Fix<Instance>;
 
         static create<Instance, Args,
-            T1 extends EmberClassArguments<Args>>(
+            T1 extends EmberInstanceArguments<Args>>(
             this: EmberClassConstructor<Instance & ComputedProperties<Args>>,
             arg1: T1 & ThisType<Fix<T1 & Instance>>
         ): Fix<Instance & T1>;
 
         static create<Instance, Args,
-            T1 extends EmberClassArguments<Args>,
-            T2 extends EmberClassArguments<Args>>(
+            T1 extends EmberInstanceArguments<Args>,
+            T2 extends EmberInstanceArguments<Args>>(
             this: EmberClassConstructor<Instance & ComputedProperties<Args>>,
             arg1: T1 & ThisType<Fix<Instance & T1>>,
             arg2: T2 & ThisType<Fix<Instance & T1 & T2>>
         ): Fix<Instance & T1 & T2>;
 
         static create<Instance, Args,
-            T1 extends EmberClassArguments<Args>,
-            T2 extends EmberClassArguments<Args>,
-            T3 extends EmberClassArguments<Args>>(
+            T1 extends EmberInstanceArguments<Args>,
+            T2 extends EmberInstanceArguments<Args>,
+            T3 extends EmberInstanceArguments<Args>>(
             this: EmberClassConstructor<Instance & ComputedProperties<Args>>,
             arg1: T1 & ThisType<Fix<Instance & T1>>,
             arg2: T2 & ThisType<Fix<Instance & T1 & T2>>,
@@ -689,36 +699,36 @@ export namespace Ember {
             this: Statics & EmberClassConstructor<Instance>
         ): Objectify<Statics> & EmberClassConstructor<Instance>;
 
-        static extend<Statics, Instance extends B1,
-            T1 extends EmberClassArguments<Instance>, B1>(
-            this: Statics & EmberClassConstructor<Instance>,
+        static extend<Statics, Args, Instance extends B1,
+            T1 extends EmberClassArguments<Args>, B1>(
+            this: Statics & EmberClassConstructor<Instance & ComputedProperties<Args>>,
             arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>
         ): Objectify<Statics> & EmberClassConstructor<T1 & Instance>;
 
-        static extend<Statics, Instance extends B1 & B2,
-            T1 extends EmberClassArguments<Instance>, B1,
-            T2 extends EmberClassArguments<Instance>, B2>(
-            this: Statics & EmberClassConstructor<Instance>,
+        static extend<Statics, Args, Instance extends B1 & B2,
+            T1 extends EmberClassArguments<Args>, B1,
+            T2 extends EmberClassArguments<Args>, B2>(
+            this: Statics & EmberClassConstructor<Instance & ComputedProperties<Args>>,
             arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
             arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>
         ): Objectify<Statics> & EmberClassConstructor<T1 & T2 & Instance>;
 
-        static extend<Statics, Instance extends B1 & B2 & B3,
-            T1 extends EmberClassArguments<Instance>, B1,
-            T2 extends EmberClassArguments<Instance>, B2,
-            T3 extends EmberClassArguments<Instance>, B3>(
-            this: Statics & EmberClassConstructor<Instance>,
+        static extend<Statics, Args, Instance extends B1 & B2 & B3,
+            T1 extends EmberClassArguments<Args>, B1,
+            T2 extends EmberClassArguments<Args>, B2,
+            T3 extends EmberClassArguments<Args>, B3>(
+            this: Statics & EmberClassConstructor<Instance & ComputedProperties<Args>>,
             arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
             arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>,
             arg3: MixinOrLiteral<T3, B3> & ThisType<Fix<Instance & T1 & T2 & T3>>
         ): Objectify<Statics> & EmberClassConstructor<T1 & T2 & T3 & Instance>;
 
-        static extend<Statics, Instance extends B1 & B2 & B3 & B4,
-            T1 extends EmberClassArguments<Instance>, B1,
-            T2 extends EmberClassArguments<Instance>, B2,
-            T3 extends EmberClassArguments<Instance>, B3,
-            T4 extends EmberClassArguments<Instance>, B4>(
-            this: Statics & EmberClassConstructor<Instance>,
+        static extend<Statics, Args, Instance extends B1 & B2 & B3 & B4,
+            T1 extends EmberClassArguments<Args>, B1,
+            T2 extends EmberClassArguments<Args>, B2,
+            T3 extends EmberClassArguments<Args>, B3,
+            T4 extends EmberClassArguments<Args>, B4>(
+            this: Statics & EmberClassConstructor<Instance & ComputedProperties<Args>>,
             arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
             arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>,
             arg3: MixinOrLiteral<T3, B3> & ThisType<Fix<Instance & T1 & T2 & T3>>,

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -725,13 +725,55 @@ export namespace Ember {
             arg4: MixinOrLiteral<T4, B4> & ThisType<Fix<Instance & T1 & T2 & T3 & T4>>
         ): Objectify<Statics> & EmberClassConstructor<T1 & T2 & T3 & T4 & Instance>;
 
-        static reopen<Statics, Instance, Extra extends EmberClassArguments<Instance>>(
-            this: Statics & EmberClassConstructor<Instance>,
-            args?: Extra & ThisType<Fix<Instance & Extra>>
-        ): Objectify<Statics> & EmberClassConstructor<Instance & Extra>;
+        static reopen<Statics, Instance>(
+            this: Statics & EmberClassConstructor<Instance>
+        ): Objectify<Statics> & EmberClassConstructor<Instance>;
 
-        static reopenClass<Class, Extra extends EmberClassArguments<Class>>(
-            this: Class, args?: Extra): Class & Extra;
+        static reopen<Statics, Instance,
+            T1 extends EmberClassArguments<Instance>, B1>(
+            this: Statics & EmberClassConstructor<Instance>,
+            arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>
+        ): Objectify<Statics> & EmberClassConstructor<Instance & T1>;
+
+        static reopen<Statics, Instance,
+            T1 extends EmberClassArguments<Instance>, B1,
+            T2 extends EmberClassArguments<Instance>, B2>(
+            this: Statics & EmberClassConstructor<Instance>,
+            arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
+            arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>
+        ): Objectify<Statics> & EmberClassConstructor<Instance & T1 & T2>;
+
+        static reopen<Statics, Instance,
+            T1 extends EmberClassArguments<Instance>, B1,
+            T2 extends EmberClassArguments<Instance>, B2,
+            T3 extends EmberClassArguments<Instance>, B3>(
+            this: Statics & EmberClassConstructor<Instance>,
+            arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
+            arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>,
+            arg3: MixinOrLiteral<T3, B3> & ThisType<Fix<Instance & T1 & T2 & T3>>
+        ): Objectify<Statics> & EmberClassConstructor<Instance & T1 & T2 & T3>;
+
+        static reopenClass<Statics>(
+            this: Statics
+        ): Statics;
+
+        static reopenClass<Statics,
+            T1 extends EmberClassArguments<Statics>>(
+            this: Statics, arg1: T1
+        ): Statics & T1;
+
+        static reopenClass<Statics,
+            T1 extends EmberClassArguments<Statics>,
+            T2 extends EmberClassArguments<Statics>>(
+            this: Statics, arg1: T1, arg2: T2
+        ): Statics & T1 & T2;
+
+        static reopenClass<Statics,
+            T1 extends EmberClassArguments<Statics>,
+            T2 extends EmberClassArguments<Statics>,
+            T3 extends EmberClassArguments<Statics>>(
+            this: Statics, arg1: T1, arg2: T2, arg3: T3
+        ): Statics & T1 & T2 & T3;
 
         static detect<Statics, Instance>(
             this: Statics & EmberClassConstructor<Instance>,

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -666,12 +666,6 @@ export namespace Ember {
             args: Extensions & ThisType<Fix<Extensions & Instance>>
         ): Fix<Instance & Extensions>;
 
-        static createWithMixins<Instance extends M1Base, M1, M1Base, Extensions extends EmberClassArguments<Instance>>(
-            this: EmberClassConstructor<Instance>,
-            mixin1: MixinOrLiteral<M1, M1Base>,
-            args?: Extensions & ThisType<Fix<Extensions & Instance & M1>>
-        ): Extensions & Instance & M1;
-
         static extend<Statics, Instance>(
             this: Statics & EmberClassConstructor<Instance>
         ): Objectify<Statics> & EmberClassConstructor<Instance>;

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -661,10 +661,29 @@ export namespace Ember {
             this: EmberClassConstructor<Instance>
         ): Fix<Instance>;
 
-        static create<Instance, Args, Extensions extends EmberClassArguments<Args>>(
+        static create<Instance, Args,
+            T1 extends EmberClassArguments<Args>>(
             this: EmberClassConstructor<Instance & ComputedProperties<Args>>,
-            args: Extensions & ThisType<Fix<Extensions & Instance>>
-        ): Fix<Instance & Extensions>;
+            arg1: T1 & ThisType<Fix<T1 & Instance>>
+        ): Fix<Instance & T1>;
+
+        static create<Instance, Args,
+            T1 extends EmberClassArguments<Args>,
+            T2 extends EmberClassArguments<Args>>(
+            this: EmberClassConstructor<Instance & ComputedProperties<Args>>,
+            arg1: T1 & ThisType<Fix<Instance & T1>>,
+            arg2: T2 & ThisType<Fix<Instance & T1 & T2>>
+        ): Fix<Instance & T1 & T2>;
+
+        static create<Instance, Args,
+            T1 extends EmberClassArguments<Args>,
+            T2 extends EmberClassArguments<Args>,
+            T3 extends EmberClassArguments<Args>>(
+            this: EmberClassConstructor<Instance & ComputedProperties<Args>>,
+            arg1: T1 & ThisType<Fix<Instance & T1>>,
+            arg2: T2 & ThisType<Fix<Instance & T1 & T2>>,
+            arg3: T3 & ThisType<Fix<Instance & T1 & T2 & T3>>
+        ): Fix<Instance & T1 & T2 & T3>;
 
         static extend<Statics, Instance>(
             this: Statics & EmberClassConstructor<Instance>

--- a/types/ember/test/computed.ts
+++ b/types/ember/test/computed.ts
@@ -83,4 +83,21 @@ const person2 = Person.create({
     fullName: 'Fred Smith'
 });
 
+assertType<string>(person2.get('firstName'));
 assertType<string>(person2.get('fullName'));
+
+const person3 = Person.extend({
+    firstName: 'Fred',
+    fullName: 'Fred Smith'
+}).create();
+
+assertType<string>(person3.get('firstName'));
+assertType<string>(person3.get('fullName'));
+
+const person4 = Person.extend({
+    firstName: Ember.computed(() => 'Fred'),
+    fullName: Ember.computed(() => 'Fred Smith')
+}).create();
+
+assertType<string>(person4.get('firstName'));
+assertType<string>(person4.get('fullName'));

--- a/types/ember/test/create.ts
+++ b/types/ember/test/create.ts
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+import { assertType } from './lib/assert';
+
+const obj = Ember.Object.create({ a: 1 }, { b: 2 }, { c: 3 });
+assertType<number>(obj.a);
+assertType<number>(obj.b);
+assertType<number>(obj.c);

--- a/types/ember/test/mixin.ts
+++ b/types/ember/test/mixin.ts
@@ -44,11 +44,3 @@ const obj = LiteralMixins.create();
 assertType<number>(obj.a);
 assertType<number>(obj.b);
 assertType<number>(obj.c);
-
-const Post = Ember.Route.extend({
-    postId: 0
-});
-
-const editablePost = Post.createWithMixins(EditableMixin);
-assertType<number>(editablePost.postId);
-editablePost.edit();

--- a/types/ember/test/reopen.ts
+++ b/types/ember/test/reopen.ts
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { assertType } from "./lib/assert";
 
+type Person = typeof Person.prototype;
 const Person = Ember.Object.extend({
     name: '',
     sayHello() {
@@ -8,13 +9,15 @@ const Person = Ember.Object.extend({
     }
 });
 
+assertType<Person>(Person.reopen());
+
 assertType<string>(Person.create().name);
 assertType<void>(Person.create().sayHello());
 
 const Person2 = Person.reopenClass({
     species: 'Homo sapiens',
 
-    createPerson(name: string): typeof Person.prototype {
+    createPerson(name: string): Person {
         return Person.create({ name });
     }
 });
@@ -45,3 +48,18 @@ person3.get('name');
 person3.get('goodbyeMessage');
 person3.sayHello();
 person3.sayGoodbye();
+
+interface AutoResizeMixin { resizable: true; }
+declare const AutoResizeMixin: Ember.Mixin<AutoResizeMixin>;
+
+const ResizableTextArea = Ember.TextArea.reopen(AutoResizeMixin, {
+    scaling: 1.0
+});
+const text = ResizableTextArea.create();
+assertType<boolean>(text.resizable);
+assertType<number>(text.scaling);
+
+const Reopened = Ember.Object.reopenClass({ a: 1 }, { b: 2 }, { c: 3 });
+assertType<number>(Reopened.a);
+assertType<number>(Reopened.b);
+assertType<number>(Reopened.c);

--- a/types/ember/tsconfig.json
+++ b/types/ember/tsconfig.json
@@ -18,6 +18,7 @@
         "test/lib/assert.ts",
         "test/ember-tests.ts",
         "test/extend.ts",
+        "test/create.ts",
         "test/object.ts",
         "test/mixin.ts",
         "test/reopen.ts",


### PR DESCRIPTION
- Remove `createWithMixins`, it was removed from ember 2.0
- Add variable-argument overloads for `create`, `reopen`, `reopenClass`

Typically used like
```ts
MyClass.reopen(Mixin1, Mixin2, {
  ...
})
```

- `extend()` allows `T` to be assignable to `ComputedProperty<T>`, and vice-versa

Fixes the case where headers might be a value or a computed property
```ts
const Customized = DS.JSONAPIAdapter.extend({
    headers: {
        'API_KEY': 'secret key',
        'ANOTHER_HEADER': 'Some header value'
    }
});

const AuthTokenHeader = DS.JSONAPIAdapter.extend({
    headers: Ember.computed('session.authToken', function() {
        return {
            'API_KEY': this.get('session.authToken'),
            'ANOTHER_HEADER': 'Some header value'
        };
    })
});
```