### PR TITLE
remove `extend()` argument type-checking

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -204,14 +204,11 @@ type EmberInstanceArguments<T> = Partial<T> & {
 };
 
 /**
- * Check that any arguments to `extend()` match the type's properties.
- *
- * For any property type `K`, `K` and `ComputedProperty<K>` are both assignable.
  * Accept any additional properties and add merge them into the prototype.
  */
-type EmberClassArguments<T> = Partial<ComputedProperties<T>> & {
-    [key: string]: any
-};
+interface EmberClassArguments {
+    [key: string]: any;
+}
 
 /**
  * Map type `T` to a plain object hash with the identity mapping.
@@ -699,36 +696,36 @@ export namespace Ember {
             this: Statics & EmberClassConstructor<Instance>
         ): Objectify<Statics> & EmberClassConstructor<Instance>;
 
-        static extend<Statics, Args, Instance extends B1,
-            T1 extends EmberClassArguments<Args>, B1>(
-            this: Statics & EmberClassConstructor<Instance & ComputedProperties<Args>>,
+        static extend<Statics, Instance extends B1,
+            T1 extends EmberClassArguments, B1>(
+            this: Statics & EmberClassConstructor<Instance>,
             arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>
         ): Objectify<Statics> & EmberClassConstructor<T1 & Instance>;
 
-        static extend<Statics, Args, Instance extends B1 & B2,
-            T1 extends EmberClassArguments<Args>, B1,
-            T2 extends EmberClassArguments<Args>, B2>(
-            this: Statics & EmberClassConstructor<Instance & ComputedProperties<Args>>,
+        static extend<Statics, Instance extends B1 & B2,
+            T1 extends EmberClassArguments, B1,
+            T2 extends EmberClassArguments, B2>(
+            this: Statics & EmberClassConstructor<Instance>,
             arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
             arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>
         ): Objectify<Statics> & EmberClassConstructor<T1 & T2 & Instance>;
 
-        static extend<Statics, Args, Instance extends B1 & B2 & B3,
-            T1 extends EmberClassArguments<Args>, B1,
-            T2 extends EmberClassArguments<Args>, B2,
-            T3 extends EmberClassArguments<Args>, B3>(
-            this: Statics & EmberClassConstructor<Instance & ComputedProperties<Args>>,
+        static extend<Statics, Instance extends B1 & B2 & B3,
+            T1 extends EmberClassArguments, B1,
+            T2 extends EmberClassArguments, B2,
+            T3 extends EmberClassArguments, B3>(
+            this: Statics & EmberClassConstructor<Instance>,
             arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
             arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>,
             arg3: MixinOrLiteral<T3, B3> & ThisType<Fix<Instance & T1 & T2 & T3>>
         ): Objectify<Statics> & EmberClassConstructor<T1 & T2 & T3 & Instance>;
 
-        static extend<Statics, Args, Instance extends B1 & B2 & B3 & B4,
-            T1 extends EmberClassArguments<Args>, B1,
-            T2 extends EmberClassArguments<Args>, B2,
-            T3 extends EmberClassArguments<Args>, B3,
-            T4 extends EmberClassArguments<Args>, B4>(
-            this: Statics & EmberClassConstructor<Instance & ComputedProperties<Args>>,
+        static extend<Statics, Instance extends B1 & B2 & B3 & B4,
+            T1 extends EmberClassArguments, B1,
+            T2 extends EmberClassArguments, B2,
+            T3 extends EmberClassArguments, B3,
+            T4 extends EmberClassArguments, B4>(
+            this: Statics & EmberClassConstructor<Instance>,
             arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
             arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>,
             arg3: MixinOrLiteral<T3, B3> & ThisType<Fix<Instance & T1 & T2 & T3>>,
@@ -740,23 +737,23 @@ export namespace Ember {
         ): Objectify<Statics> & EmberClassConstructor<Instance>;
 
         static reopen<Statics, Instance,
-            T1 extends EmberClassArguments<Instance>, B1>(
+            T1 extends EmberClassArguments, B1>(
             this: Statics & EmberClassConstructor<Instance>,
             arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>
         ): Objectify<Statics> & EmberClassConstructor<Instance & T1>;
 
         static reopen<Statics, Instance,
-            T1 extends EmberClassArguments<Instance>, B1,
-            T2 extends EmberClassArguments<Instance>, B2>(
+            T1 extends EmberClassArguments, B1,
+            T2 extends EmberClassArguments, B2>(
             this: Statics & EmberClassConstructor<Instance>,
             arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
             arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>
         ): Objectify<Statics> & EmberClassConstructor<Instance & T1 & T2>;
 
         static reopen<Statics, Instance,
-            T1 extends EmberClassArguments<Instance>, B1,
-            T2 extends EmberClassArguments<Instance>, B2,
-            T3 extends EmberClassArguments<Instance>, B3>(
+            T1 extends EmberClassArguments, B1,
+            T2 extends EmberClassArguments, B2,
+            T3 extends EmberClassArguments, B3>(
             this: Statics & EmberClassConstructor<Instance>,
             arg1: MixinOrLiteral<T1, B1> & ThisType<Fix<Instance & T1>>,
             arg2: MixinOrLiteral<T2, B2> & ThisType<Fix<Instance & T1 & T2>>,
@@ -768,20 +765,20 @@ export namespace Ember {
         ): Statics;
 
         static reopenClass<Statics,
-            T1 extends EmberClassArguments<Statics>>(
+            T1 extends EmberClassArguments>(
             this: Statics, arg1: T1
         ): Statics & T1;
 
         static reopenClass<Statics,
-            T1 extends EmberClassArguments<Statics>,
-            T2 extends EmberClassArguments<Statics>>(
+            T1 extends EmberClassArguments,
+            T2 extends EmberClassArguments>(
             this: Statics, arg1: T1, arg2: T2
         ): Statics & T1 & T2;
 
         static reopenClass<Statics,
-            T1 extends EmberClassArguments<Statics>,
-            T2 extends EmberClassArguments<Statics>,
-            T3 extends EmberClassArguments<Statics>>(
+            T1 extends EmberClassArguments,
+            T2 extends EmberClassArguments,
+            T3 extends EmberClassArguments>(
             this: Statics, arg1: T1, arg2: T2, arg3: T3
         ): Statics & T1 & T2 & T3;
 


### PR DESCRIPTION
@chriskrycho I think this is the "Property ‘__ember_mixin__’ is missing in type ‘<the type definition>’" problem you found.

This trivial code fails to compile with a confusing error
```ts
Ember.Route.extend({
    beforeModel(transition) {
    }
});
```

> Error:(3, 20) TS2345:Argument of type '{ beforeModel(transition: any): void; }' is not assignable to parameter of type '(Partial<ComputedProperties<{ activate: Function; afterModel: (resolvedModel: any, transition: Tr...'.
  Type '{ beforeModel(transition: any): void; }' is not assignable to type 'Mixin<EmberClassArguments<{ activate: Function; afterModel: (resolvedModel: any, transition: Tran...'.
    Type '{ beforeModel(transition: any): void; }' is not assignable to type 'Mixin<EmberClassArguments<{ activate: Function; afterModel: (resolvedModel: any, transition: Tran...'.
      Property '__ember_mixin__' is missing in type '{ beforeModel(transition: any): void; }'.

---

This happens because arguments to `extend` are type-checked against the class definition. `beforeModel` is defined as
```ts
class Route {
  beforeModel(transition: Transition): Rsvp.Promise<any, any>;
}
```

And the code did not return a promise. This could be corrected by adding `void` as a return type:
```ts
class Route {
  beforeModel(transition: Transition): Rsvp.Promise<any, any> | void;
}
```

Realistically the error message is not useful at all. I think we should get rid of these checks.