### PR TITLE
[WIP] give the computed macros a precise type

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1887,7 +1887,7 @@ export namespace Ember {
         defaultTo(defaultPath: string): ComputedProperty<any>;
         deprecatingAlias(dependentKey: string, options: DeprecateOptions): ComputedProperty<any>;
         empty(dependentKey: string): ComputedProperty<any>;
-        equal(dependentKey: string, value: any): ComputedProperty<any>;
+        equal(dependentKey: string, value: any): ComputedProperty<boolean>;
         filter(
             dependentKey: string,
             callback: (item: any, index?: number, array?: any[]) => boolean


### PR DESCRIPTION
This PR is here to be give a return type more precise than `ComputedProperty<any>` to the computed macros

This way, when you use a macro for a property in an object and try to assign an incorrect value, Typescript will let you know

```typescript
import EmberObject, {set} from '@ember/object';
import {equal} from '@ember/object/computed';

export default class extends EmberObject {
  foo = equal('dependentKey', 'value')

  dummy() {
    set(this, 'foo', 1); // Typescript should shout here
  }
}
```