### PR TITLE
Try adding `this` to RSVP typings.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
     "tabWidth": 4,
+    "printWidth": 100,
     "singleQuote": true,
     "trailingComma": "es5"
 }

--- a/types/rsvp/index.d.ts
+++ b/types/rsvp/index.d.ts
@@ -267,44 +267,122 @@ declare module 'rsvp' {
         //
         // That day, however, may never come. So, in the meantime, we do this.
 
+        function denodeify<This, T1, T2, T3, A>(
+            nodeFunc: (
+                this: This,
+                arg1: A,
+                callback: (err: any, data1: T1, data2: T2, data3: T3) => void
+            ) => void,
+            options?: false
+        ): (this: This, arg1: A) => RSVP.Promise<T1>;
+
         function denodeify<T1, T2, T3, A>(
             nodeFunc: (
+                this: void,
                 arg1: A,
                 callback: (err: any, data1: T1, data2: T2, data3: T3) => void
             ) => void,
             options?: false
         ): (arg1: A) => RSVP.Promise<T1>;
 
+        function denodeify<This, T1, T2, A>(
+            nodeFunc: (
+                this: This,
+                arg1: A,
+                callback: (err: any, data1: T1, data2: T2) => void
+            ) => void,
+            options?: false
+        ): (this: This, arg1: A) => RSVP.Promise<T1>;
+
         function denodeify<T1, T2, A>(
-            nodeFunc: (arg1: A, callback: (err: any, data1: T1, data2: T2) => void) => void,
+            nodeFunc: (
+                this: void,
+                arg1: A,
+                callback: (err: any, data1: T1, data2: T2) => void
+            ) => void,
             options?: false
         ): (arg1: A) => RSVP.Promise<T1>;
 
+        function denodeify<This, T, A>(
+            nodeFunc: (this: This, arg1: A, callback: (err: any, data: T) => void) => void,
+            options?: false
+        ): (this: This, arg1: A) => RSVP.Promise<T>;
+
         function denodeify<T, A>(
-            nodeFunc: (arg1: A, callback: (err: any, data: T) => void) => void,
+            nodeFunc: (this: void, arg1: A, callback: (err: any, data: T) => void) => void,
             options?: false
         ): (arg1: A) => RSVP.Promise<T>;
 
+        function denodeify<This, T1, T2, T3, A>(
+            nodeFunc: (
+                this: This,
+                arg1: A,
+                callback: (err: any, data1: T1, data2: T2, data3: T3) => void
+            ) => void,
+            options: true
+        ): (this: This, arg1: A) => RSVP.Promise<[T1, T2, T3]>;
+
         function denodeify<T1, T2, T3, A>(
             nodeFunc: (
+                this: void,
                 arg1: A,
                 callback: (err: any, data1: T1, data2: T2, data3: T3) => void
             ) => void,
             options: true
         ): (arg1: A) => RSVP.Promise<[T1, T2, T3]>;
 
+        function denodeify<This, T1, T2, A>(
+            nodeFunc: (
+                this: This,
+                arg1: A,
+                callback: (err: any, data1: T1, data2: T2) => void
+            ) => void,
+            options: true
+        ): (this: This, arg1: A) => RSVP.Promise<[T1, T2]>;
+
         function denodeify<T1, T2, A>(
-            nodeFunc: (arg1: A, callback: (err: any, data1: T1, data2: T2) => void) => void,
+            nodeFunc: (
+                this: void,
+                arg1: A,
+                callback: (err: any, data1: T1, data2: T2) => void
+            ) => void,
             options: true
         ): (arg1: A) => RSVP.Promise<[T1, T2]>;
 
+        function denodeify<This, T, A>(
+            nodeFunc: (this: This, arg1: A, callback: (err: any, data: T) => void) => void,
+            options: true
+        ): (this: This, arg1: A) => RSVP.Promise<[T]>;
+
         function denodeify<T, A>(
-            nodeFunc: (arg1: A, callback: (err: any, data: T) => void) => void,
+            nodeFunc: (this: void, arg1: A, callback: (err: any, data: T) => void) => void,
             options: true
         ): (arg1: A) => RSVP.Promise<[T]>;
 
+        function denodeify<
+            This,
+            T1,
+            T2,
+            T3,
+            A,
+            K1 extends string,
+            K2 extends string,
+            K3 extends string
+        >(
+            nodeFunc: (
+                this: This,
+                arg1: A,
+                callback: (err: any, data1: T1, data2: T2, data3: T3) => void
+            ) => void,
+            options: [K1, K2, K3]
+        ): (
+            this: This,
+            arg1: A
+        ) => RSVP.Promise<{ [K in K1]: T1 } & { [K in K2]: T2 } & { [K in K3]: T3 }>;
+
         function denodeify<T1, T2, T3, A, K1 extends string, K2 extends string, K3 extends string>(
             nodeFunc: (
+                this: void,
                 arg1: A,
                 callback: (err: any, data1: T1, data2: T2, data3: T3) => void
             ) => void,
@@ -312,12 +390,30 @@ declare module 'rsvp' {
         ): (arg1: A) => RSVP.Promise<{ [K in K1]: T1 } & { [K in K2]: T2 } & { [K in K3]: T3 }>;
 
         function denodeify<T1, T2, A, K1 extends string, K2 extends string>(
-            nodeFunc: (arg1: A, callback: (err: any, data1: T1, data2: T2) => void) => void,
+            nodeFunc: (
+                this: void,
+                arg1: A,
+                callback: (err: any, data1: T1, data2: T2) => void
+            ) => void,
             options: [K1, K2]
         ): (arg1: A) => RSVP.Promise<{ [K in K1]: T1 } & { [K in K2]: T2 }>;
 
+        function denodeify<This, T1, T2, A, K1 extends string, K2 extends string>(
+            nodeFunc: (
+                this: This,
+                arg1: A,
+                callback: (err: any, data1: T1, data2: T2) => void
+            ) => void,
+            options: [K1, K2]
+        ): (this: This, arg1: A) => RSVP.Promise<{ [K in K1]: T1 } & { [K in K2]: T2 }>;
+
+        function denodeify<This, T, A, K1 extends string>(
+            nodeFunc: (this: This, arg1: A, callback: (err: any, data: T) => void) => void,
+            options: [K1]
+        ): (this: This, arg1: A) => RSVP.Promise<{ [K in K1]: T }>;
+
         function denodeify<T, A, K1 extends string>(
-            nodeFunc: (arg1: A, callback: (err: any, data: T) => void) => void,
+            nodeFunc: (this: void, arg1: A, callback: (err: any, data: T) => void) => void,
             options: [K1]
         ): (arg1: A) => RSVP.Promise<{ [K in K1]: T }>;
 

--- a/types/rsvp/rsvp-tests.ts
+++ b/types/rsvp/rsvp-tests.ts
@@ -177,6 +177,21 @@ function testDenodeify() {
         console.log(value.quux + 1);
         console.log(value.baz.length);
     });
+
+    class Quux {
+        foo?: string;
+
+        baz(arg: number, callback: (err: any, data1: number, data2: string) => void): void {
+            this.foo = 'oh weird';
+            callback(null, arg, arg.toString());
+        }
+    }
+
+    const quux = new Quux();
+    const baz = RSVP.denodeify(quux.baz, ['theValue', 'itsLength']);
+
+    baz(123); // NOTE: if you uncomment this, it will fail.
+    baz.call(quux, baz);
 }
 
 function testFilter() {


### PR DESCRIPTION
Note that I've tried this with the orderings either direction; I can make *either* the non-`this`-maintaining version *or* the `this`-maintaining version work, depending on whether I put the `this: This` version or the `this: void` version first.