### PR TITLE
Add typings for ember-mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "dtslint types"
   },
   "devDependencies": {
+    "@types/chai": "^4.0.4",
     "dts-gen": "^0.5.6",
     "dtslint": "Microsoft/dtslint#production",
     "prettier": "^1.7.0",

--- a/types/ember-mocha/ember-mocha-tests.ts
+++ b/types/ember-mocha/ember-mocha-tests.ts
@@ -62,7 +62,7 @@ describeComponent.skip(
     {
         integration: true
     },
-    function () {
+    function() {
     }
 );
 

--- a/types/ember-mocha/ember-mocha-tests.ts
+++ b/types/ember-mocha/ember-mocha-tests.ts
@@ -1,0 +1,184 @@
+import {
+    describeComponent, describeModel, describeModule,
+    setResolver, setupAcceptanceTest, setupComponentTest,
+    setupModelTest, setupTest
+} from 'ember-mocha';
+import { describe, it, beforeEach, afterEach, before, after } from 'mocha';
+import chai = require('chai');
+import Ember from "ember";
+import hbs from 'htmlbars-inline-precompile';
+
+describeModule('name', function() {
+    beforeEach(function() {
+    });
+
+    it('test', function() {
+    });
+});
+
+describeModule('name', 'description', function() {
+    it('test', function() {
+    });
+});
+
+describeModule(
+    'name',
+    'description',
+    {
+        needs: ['service:notifications']
+    },
+    function() {
+    }
+);
+
+describeModule('component:x-foo', 'TestModule callbacks', {
+    needs: [],
+
+    beforeSetup() {
+    },
+    setup() {
+    },
+    teardown() {
+    },
+    afterTeardown() {
+    }
+}, function() {
+});
+
+describeComponent('x-foo', {
+    integration: true
+}, function() {
+});
+
+describeComponent('x-foo', {
+    unit: true,
+    needs: ['helper:pluralize-string']
+}, function() {
+});
+
+describeComponent.skip(
+    'block-slot',
+    'Integration: BlockSlotComponent',
+    {
+        integration: true
+    },
+    function () {
+    }
+);
+
+describeModel('user', {
+    needs: ['model:child']
+}, function() {
+});
+
+describeModule('component:x-foo', 'TestModule callbacks', function() {
+    before(function() {
+        this.skip();
+        this.timeout(1000);
+        this.registry.register('helper:i18n', {});
+        this.register('service:i18n', {});
+        this.inject.service('i18n');
+        this.inject.service('i18n', { as: 'i18n' });
+        this.factory('object:user').create();
+    });
+
+    after(function() {
+    });
+
+    beforeEach(function() {
+    });
+
+    afterEach(function() {
+    });
+});
+
+describe('setupTest', function() {
+    setupTest();
+
+    setupTest('service:ajax');
+
+    setupTest('service:ajax', {
+        unit: true
+    });
+
+    setupTest('controller:sidebar', {
+        // Specify the other units that are required for this test.
+        // needs: ['controller:foo']
+    });
+
+    setupComponentTest('gravatar-image', {
+        // specify the other units that are required for this test
+        // needs: ['component:foo', 'helper:bar']
+    });
+
+    setupModelTest('contact', {
+        // Specify the other units that are required for this test.
+        needs: []
+    });
+
+    const Application = Ember.Application.extend();
+
+    setupAcceptanceTest({ Application });
+
+    it('test', function() {
+    });
+});
+
+// if you don't have a custom resolver, do it like this:
+setResolver(Ember.DefaultResolver.create());
+
+it('renders', function() {
+    // setup the outer context
+    this.set('value', 'cat');
+    this.on('action', function(result) {
+        chai.expect(result).to.equal('bar', 'The correct result was returned');
+        chai.expect(this.get('value')).to.equal('cat');
+    });
+
+    // render the component
+    this.render(hbs`
+        {{ x-foo value=value action="result" }}
+    `);
+    this.render('{{ x-foo value=value action="result" }}');
+    this.render([
+        '{{ x-foo value=value action="result" }}'
+    ]);
+
+    chai.expect(this.$('div>.value').text()).to.equal('cat', 'The component shows the correct value');
+
+    this.$('button').click();
+});
+
+it('renders', function() {
+    // creates the component instance
+    const subject = this.subject();
+
+    const subject2 = this.subject({
+        item: 42
+    });
+
+    const { inputFormat } = this.setProperties({
+        inputFormat: 'M/D/YY',
+        outputFormat: 'MMMM D, YYYY',
+        date: '5/3/10'
+    });
+
+    const { inputFormat: if2, outputFormat } = this.getProperties('inputFormat', 'outputFormat');
+
+    const inputFormat2 = this.get('inputFormat');
+
+    // render the component on the page
+    this.render();
+    chai.expect(this.$('.foo').text()).to.equal('bar');
+});
+
+it('can calculate the result', function(assert) {
+    const subject = this.subject();
+
+    subject.set('value', 'foo');
+    chai.assert.equal(subject.get('result'), 'bar');
+});
+
+it.skip('disabled test');
+
+it.skip('disabled test', function() { });

--- a/types/ember-mocha/index.d.ts
+++ b/types/ember-mocha/index.d.ts
@@ -1,0 +1,174 @@
+// Type definitions for ember-mocha 0.12
+// Project: https://github.com/emberjs/ember-mocha#readme
+// Definitions by: Derek Wickern <https://github.com/dwickern>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+declare module 'ember-mocha' {
+    import Ember from 'ember';
+    import { it as mochaIt, SuiteCallbackContext } from 'mocha';
+
+    interface ModuleCallbacks {
+        integration?: boolean;
+        unit?: boolean;
+        needs?: string[];
+
+        beforeSetup?(): void;
+        setup?(): void;
+        teardown?(): void;
+        afterTeardown?(): void;
+
+        [key: string]: any;
+    }
+
+    interface ContextDefinitionFunction {
+        (name: string, description: string, callbacks: ModuleCallbacks, tests: (this: SuiteCallbackContext) => void): void;
+        (name: string, description: string, tests: (this: SuiteCallbackContext) => void): void;
+        (name: string, callbacks: ModuleCallbacks, tests: (this: SuiteCallbackContext) => void): void;
+        (name: string, tests: (this: SuiteCallbackContext) => void): void;
+    }
+
+    interface ContextDefinition extends ContextDefinitionFunction {
+        only: ContextDefinitionFunction;
+        skip: ContextDefinitionFunction;
+    }
+
+    interface SetupTest {
+        (name?: string): void;
+        (name: string, callbacks?: ModuleCallbacks): void;
+        (callbacks: ModuleCallbacks): void;
+    }
+
+    /**
+     *
+     * @param {string} fullName The full name of the unit, ie controller:application, route:index.
+     * @param {string} description The description of the module
+     * @param {ModuleCallbacks} callbacks
+     * @deprecated Use setupTest instead
+     */
+    export const describeModule: ContextDefinition;
+
+    /**
+     *
+     * @param {string} fullName the short name of the component that you'd use in a template, ie x-foo, ic-tabs, etc.
+     * @param {string} description The description of the module
+     * @param {ModuleCallbacks} callbacks
+     * @deprecated Use setupComponentTest instead
+     */
+    export const describeComponent: ContextDefinition;
+
+    /**
+     *
+     * @param {string} fullName the short name of the model you'd use in store operations ie user, assignmentGroup, etc.
+     * @param {string} description The description of the module
+     * @param {ModuleCallbacks} callbacks
+     * @deprecated Use setupModelTest instead
+     */
+    export const describeModel: ContextDefinition;
+
+    export const setupTest: SetupTest;
+    export const setupAcceptanceTest: SetupTest;
+    export const setupComponentTest: SetupTest;
+    export const setupModelTest: SetupTest;
+
+    export const it: typeof mochaIt;
+
+    /**
+     * Sets a Resolver globally which will be used to look up objects from each test's container.
+     */
+    export function setResolver(resolver: Ember.Resolver): void;
+}
+
+declare module 'mocha' {
+    import Ember from 'ember';
+    import { TemplateFactory } from 'htmlbars-inline-precompile';
+
+    interface Runnable {
+        title: string;
+        fn: Function;
+        async: boolean;
+        sync: boolean;
+        timedOut: boolean;
+        timeout(n: number): this;
+    }
+
+    interface Suite {
+        parent: Suite;
+        title: string;
+
+        fullTitle(): string;
+    }
+
+    interface Test extends Runnable {
+        parent: Suite;
+        pending: boolean;
+        state: 'failed' | 'passed' | undefined;
+
+        fullTitle(): string;
+    }
+
+    interface TestContext {
+        skip(): this;
+        timeout(ms: number): this;
+        get(key: string): any;
+        getProperties<K extends string>(...keys: K[]): Pick<any, K>;
+        set<V>(key: string, value: V): V;
+        setProperties<P extends { [key: string]: any }>(hash: P): P;
+        on(actionName: string, handler: (this: TestContext, ...args: any[]) => any): void;
+        send(actionName: string): void;
+        $: JQueryStatic;
+        subject(options?: {}): any;
+        render(template?: string | string[] | TemplateFactory): void;
+        clearRender(): void;
+        registry: Ember.Registry;
+        container: Ember.Container;
+        dispatcher: Ember.EventDispatcher;
+        register(fullName: string, factory: any): void;
+        factory(fullName: string): any;
+        inject: {
+            controller(name: string, options?: { as: string }): any;
+            service(name: string, options?: { as: string }): any;
+        };
+    }
+
+    interface BeforeAndAfterContext extends TestContext {
+        currentTest: Test;
+    }
+
+    interface TestDefinition {
+        (expectation: string, callback?: (this: TestContext, done: MochaDone) => any): Test;
+        only(expectation: string, callback?: (this: TestContext, done: MochaDone) => any): Test;
+        skip(expectation: string, callback?: (this: TestContext, done: MochaDone) => any): void;
+        timeout(ms: number): void;
+        state: "failed" | "passed";
+    }
+
+    interface MochaDone {
+        (error?: any): any;
+    }
+
+    interface SuiteCallbackContext {
+        timeout(ms: number): this;
+        retries(n: number): this;
+        slow(ms: number): this;
+    }
+
+    interface ContextDefinition {
+        (description: string, callback: (this: SuiteCallbackContext) => void): Suite;
+        only(description: string, callback: (this: SuiteCallbackContext) => void): Suite;
+        skip(description: string, callback: (this: SuiteCallbackContext) => void): void;
+    }
+
+    // export const mocha: Mocha;
+    export const describe: ContextDefinition;
+    export const context: ContextDefinition;
+    export const it: TestDefinition;
+    export function before(callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
+    export function before(description: string, callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
+    export function after(callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
+    export function after(description: string, callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
+    export function beforeEach(callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
+    export function beforeEach(description: string, callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
+    export function afterEach(callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
+    export function afterEach(description: string, callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
+}

--- a/types/ember-mocha/index.d.ts
+++ b/types/ember-mocha/index.d.ts
@@ -34,8 +34,7 @@ declare module 'ember-mocha' {
     }
 
     interface SetupTest {
-        (name?: string): void;
-        (name: string, callbacks?: ModuleCallbacks): void;
+        (name?: string, callbacks?: ModuleCallbacks): void;
         (callbacks: ModuleCallbacks): void;
     }
 
@@ -85,7 +84,7 @@ declare module 'mocha' {
 
     interface Runnable {
         title: string;
-        fn: Function;
+        fn(...args: any[]): any;
         async: boolean;
         sync: boolean;
         timedOut: boolean;
@@ -143,9 +142,7 @@ declare module 'mocha' {
         state: "failed" | "passed";
     }
 
-    interface MochaDone {
-        (error?: any): any;
-    }
+    type MochaDone = (error?: any) => any;
 
     interface SuiteCallbackContext {
         timeout(ms: number): this;

--- a/types/ember-mocha/tsconfig.json
+++ b/types/ember-mocha/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ember-mocha-tests.ts"
+    ]
+}

--- a/types/ember-mocha/tslint.json
+++ b/types/ember-mocha/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         "only-arrow-functions": false,
         "strict-export-declare-modifiers": false,
-        "no-duplicate-imports": false
+        "no-duplicate-imports": false,
+        "unified-signatures": false
     }
 }

--- a/types/ember-mocha/tslint.json
+++ b/types/ember-mocha/tslint.json
@@ -1,0 +1,8 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "only-arrow-functions": false,
+        "strict-export-declare-modifiers": false,
+        "no-duplicate-imports": false
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/chai@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.0.4.tgz#fe86315d9a66827feeb16f73bc954688ec950e18"
+
 "@types/handlebars@^4.0.35":
   version "4.0.36"
   resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.36.tgz#ff57c77fa1ab6713bb446534ddc4d979707a3a79"


### PR DESCRIPTION
The ember-mocha types conflict with the mocha typings in DT: 

`@types/mocha` uses export assignment:
```ts
declare module "mocha" {
    export = Mocha;
}
```

`ember-mocha` uses named exports which cannot coexist with the export assignment.

To work around this I copied some of mocha's typings into ember-mocha's. When using the ember-mocha typings you should _not_ install `@types/mocha` 