### PR TITLE
Ember CLI Mirage typings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "types-publisher": "Microsoft/types-publisher#production"
   },
   "dependencies": {
+    "@types/faker": "^4.1.1",
     "@types/handlebars": "^4.0.35",
     "@types/jquery": "^3.2.11",
     "@types/qunit": "^2.0.31",

--- a/types/ember-cli-mirage/collection.d.ts
+++ b/types/ember-cli-mirage/collection.d.ts
@@ -1,4 +1,7 @@
-export interface Collection<T> {
+/**
+ * A collection of db records i.e. a database table.
+ */
+export interface Collection<T> extends ArrayLike<T> {
     /**
      * Returns a single record from the collection if ids is a single id, or an
      * array of records if ids is an array of ids. Note each id can be an int or a

--- a/types/ember-cli-mirage/collection.d.ts
+++ b/types/ember-cli-mirage/collection.d.ts
@@ -9,6 +9,13 @@ export interface Collection<T> {
     find(ids: (number | string)[]): T[];
 
     /**
+     * Returns the first model from `collection` that matches the
+     * key-value pairs in the `query` object. Note that a string
+     * comparison is used. `query` is a POJO.
+     */
+    findBy(query: object): T;
+
+    /**
      * Finds the first record matching the provided query in `Collection`, or
      * creates a new record using a merge of the query and optional
      * `attributesForCreate`.

--- a/types/ember-cli-mirage/collection.d.ts
+++ b/types/ember-cli-mirage/collection.d.ts
@@ -1,0 +1,58 @@
+export interface Collection<T> {
+    /**
+     * Returns a single record from the collection if ids is a single id, or an
+     * array of records if ids is an array of ids. Note each id can be an int or a
+     * string, but integer ids as strings (e.g. the string “1”) will be treated as
+     * integers.
+     */
+    find(id: number | string): T;
+    find(ids: (number | string)[]): T[];
+
+    /**
+     * Finds the first record matching the provided query in `Collection`, or
+     * creates a new record using a merge of the query and optional
+     * `attributesForCreate`.
+     */
+    firstOrCreate(query?: Partial<T>, attributesForCreate?: Partial<T>): T;
+
+    /**
+     * Inserts `data` into the `Collection`. `Data` can be a single object or an
+     * array of objects. Returns the inserted record.
+     */
+    insert(data: Partial<T> | Partial<T>[]): T;
+
+    /**
+     * Removes one or more records in collection.
+     *
+     * If `target` is undefined, removes all records. If `target` is a number or
+     * string, removes a single record using `target` as id. If `target` is a
+     * POJO, queries `Collection` for records that match the key-value pairs in
+     * `target`, and removes them from the collection.
+     */
+    remove(target?: number | string | Partial<T>): this;
+
+    /**
+     * Updates one or more records in `Collection`.
+     *
+     * If `attrs` is the only arg present, updates all records in the collection
+     * according to the key-value pairs in `attrs`.
+     *
+     * If `target` is present, restricts updates to those that match `target`. If
+     * `target` is a number or string, finds a single record whose id is `target`
+     * to update. If `target` is a POJO, queries collection for records that match
+     * the key-value pairs in `target`, and updates their `attrs`.
+     *
+     * Returns the updated record or records.
+     */
+    update(...attrs: Partial<T>[]): this;
+    update(target: number, ...attrs: Partial<T>[]): this;
+
+    /**
+     * Returns an array of models from `Collection` that match the key-value pairs
+     * in the query object. Note that a string comparison is used. `query` is a
+     * POJO.
+     */
+    where(query: Partial<T>): T[];
+}
+
+export default Collection;

--- a/types/ember-cli-mirage/collection.d.ts
+++ b/types/ember-cli-mirage/collection.d.ts
@@ -1,7 +1,7 @@
 /**
  * A collection of db records i.e. a database table.
  */
-export interface Collection<T> extends ArrayLike<T> {
+export interface DbCollection<T> extends ArrayLike<T> {
     /**
      * Returns a single record from the collection if ids is a single id, or an
      * array of records if ids is an array of ids. Note each id can be an int or a
@@ -65,4 +65,101 @@ export interface Collection<T> extends ArrayLike<T> {
     where(query: Partial<T>): T[];
 }
 
-export default Collection;
+export interface SchemaCollection<T> {
+    /**
+     * The name of the model in the registry
+     */
+    camelizedModelName: string;
+
+    /**
+     * Create a model without saving it
+     */
+    'new'(attrs?: Partial<T>): T;
+
+    /**
+     * Create a model and save it to the database
+     */
+    create(attrs?: Partial<T>): T;
+
+    /**
+     * List all models in the collection
+     */
+    all(): Collection<T>;
+
+    /**
+     * Returns a single record from the collection if ids is a single id, or an
+     * array of records if ids is an array of ids. Note each id can be an int or a
+     * string, but integer ids as strings (e.g. the string “1”) will be treated as
+     * integers.
+     */
+    find(id: number | string): T;
+    find(ids: (number | string)[]): Collection<T>;
+
+    /**
+     * Returns the first model from `collection` that matches the
+     * key-value pairs in the `query` object. Note that a string
+     * comparison is used. `query` is a POJO.
+     */
+    findBy(query: object): T;
+
+    /**
+     * Returns an array of models from `Collection` that match the key-value pairs
+     * in the query object. Note that a string comparison is used. `query` is a
+     * POJO.
+     */
+    where(query: Partial<T>): Collection<T>;
+
+    /**
+     * Fetch the first model from the collection
+     */
+    first(): T | null;
+}
+
+/**
+ * An array of models, returned from one of the schema query
+ * methods (all, find, where). Knows how to update and destroy its models.
+ */
+export class Collection<T> {
+    modelName: string;
+    models: T[];
+    /**
+     * Number of models in the collection.
+     */
+    length: number;
+    /**
+     * Updates each model in the collection (persisting immediately to the db).
+     */
+    update(key: string, val: any): this;
+    /**
+     * Destroys the db record for all models in the collection.
+     */
+    destroy(): this;
+    /**
+     * Saves all models in the collection.
+     */
+    save(): this;
+    /**
+     * Reloads each model in the collection.
+     */
+    reload(): this;
+    /**
+     * Adds a model to this collection
+     */
+    add(model: T): this;
+    /**
+     * Removes a model to this collection
+     */
+    remove(model: T): this;
+    /**
+     * Checks if the collection includes the model
+     */
+    includes(model: T): boolean;
+    filter(f: (item: T, index: number, models: T[]) => boolean): Collection<T>;
+    sort(compareFn?: (a: T, b: T) => number): Collection<T>;
+    slice(begin: number, end: number): Collection<T>;
+    mergeCollection(collection: Collection<T>): this;
+    /**
+     * Simple string representation of the collection and id.
+     */
+    toString(): string;
+}

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -229,5 +229,19 @@ declare namespace Mirage {
     const Factory: MirageFactory;
 }
 
-export const faker: typeof fakerStatic;
+interface MirageFakerExtras {
+    list: {
+        random<T>(first: T, ...rest: T[]): () => T ;
+        random<T>(...args: T[]): () => T | undefined;
+        cycle<T>(first: T, ...rest: T[]): () => T;
+        cycle<T>(...args: T[]): () => T | undefined;
+    },
+    random: {
+        number: {
+            range(min: number, max: number): () => number;
+        }
+    }
+}
+
+export const faker: typeof fakerStatic & MirageFakerExtras;
 export default Mirage;

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -47,6 +47,17 @@ export interface Server {
     namespace: string;
 
     /**
+     * Set the timing parameter of the response for this particular route.
+     * Default is a 400ms delay during development and 0 delay in testing (so your tests run fast).
+     */
+    timing: number;
+
+    /**
+     * Set to log all requests
+     */
+    logging: boolean;
+
+    /**
      * Generates a single model of type `type`, inserts it into the database
      * (giving it an id), and returns the data that was added. You can override
      * the attributes from the factory definition with a hash passed in as the

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -5,6 +5,7 @@
 
 import Ember from 'ember';
 import * as Registry from './registry';
+import fakerStatic = require('faker');
 
 type EmberObject = Ember.Object;
 
@@ -228,50 +229,5 @@ declare namespace Mirage {
     const Factory: MirageFactory;
 }
 
-export namespace faker {
-    const address: {
-        city(): string;
-        countryCode(): string;
-        latitude(): string;
-        longitude(): string;
-        state(): string;
-        streetAddress(): string;
-        zipCode(): string;
-    };
-
-    const commerce: {
-        price(): number;
-        product(): string;
-        productName(): string;
-        productAdjective(): string;
-        productMaterial(): string;
-    };
-
-    const hacker: {
-        noun(): string;
-    };
-
-    const internet: {
-        email(): string;
-        password(): string;
-    };
-
-    const lorem: {
-        sentence(): string;
-    };
-
-    const name: {
-        firstName(): string;
-        lastName(): string;
-    };
-
-    const phone: {
-        phoneNumber(): string;
-    };
-
-    const random: {
-        number(): number;
-    };
-}
-
+export const faker: typeof fakerStatic;
 export default Mirage;

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -42,6 +42,20 @@ type Shorthand =
     | Registry.CollectionNames
     | Array<Registry.ModelNames | Registry.CollectionNames>;
 
+interface RouteHandler {
+    // shorthands
+    (route: string): void;
+    (route: string, object: object, responseCode?: ResponseCode): void;
+    (route: string, shorthand: Shorthand, responseCode?: ResponseCode): void;
+    
+    // callbacks
+    <QP = void, T = void>(
+        route: string,
+        handler: RouteHandler<QP, T>,
+        responseCode?: ResponseCode
+    ): void;
+}
+
 export interface Server {
     /** Set the base namespace used for all routes defined with get, post, put or del. */
     namespace: string;
@@ -80,46 +94,11 @@ export interface Server {
         attrs?: Partial<Registry.Models[N]>
     ): Registry.Models[N][];
 
-    // Route handlers
-    get(route: string): void;
-    get(route: string, object: object, responseCode?: ResponseCode): void;
-    get(route: string, shorthand: Shorthand, responseCode?: ResponseCode): void;
-    get<QP = void, T = void>(
-        route: string,
-        handler: RouteHandler<QP, T>,
-        responseCode?: ResponseCode
-    ): void;
-
-    post(route: string): void;
-    post(route: string, object: object, responseCode?: ResponseCode): void;
-    post(
-        route: string,
-        shorthand: Shorthand,
-        responseCode?: ResponseCode
-    ): void;
-    post<QP = void, T = void>(
-        route: string,
-        handler: RouteHandler<QP, T>,
-        responseCode?: ResponseCode
-    ): void;
-
-    put(route: string): void;
-    put(route: string, object: object, responseCode?: ResponseCode): void;
-    put(route: string, shorthand: Shorthand, responseCode?: ResponseCode): void;
-    put<QP = void, T = void>(
-        route: string,
-        handler: RouteHandler<QP, T>,
-        responseCode?: ResponseCode
-    ): void;
-
-    del(route: string): void;
-    del(route: string, object: object, responseCode?: ResponseCode): void;
-    del(route: string, shorthand: Shorthand, responseCode?: ResponseCode): void;
-    del<QP = void, T = void>(
-        route: string,
-        handler: RouteHandler<QP, T>,
-        responseCode?: ResponseCode
-    ): void;
+    get: RouteHandler;
+    post: RouteHandler;
+    patch: RouteHandler;
+    put: RouteHandler;
+    del: RouteHandler;
 
     /**
      * By default, all the data files under `/fixtures` will be loaded during

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -1,0 +1,272 @@
+// Type definitions for ember-cli-mirage 0.1.14
+// Project: Ember-CLI-Mirage
+// Definitions by: Chris Krycho <github.com/chriskrycho>
+// Definitions: https://github.com/ololabs/mobile-web-client
+
+import Ember from 'ember';
+import * as Registry from './registry';
+
+type EmberObject = Ember.Object;
+
+interface MirageResponse {
+    new (status: number, headers?: any[], payload?: any): MirageResponse;
+}
+
+interface MirageFactory extends EmberObject {}
+
+export const Response: MirageResponse;
+export const Factory: MirageFactory;
+
+/**
+ * Your Mirage server has a database which you can interact with in your route
+ * handlers. You retrieve or modify data from the database, then return what you
+ * want for that route.
+ */
+export interface Database extends Registry.Collections {
+    createCollection(name: string): void;
+}
+
+export interface Request<QP> {
+    requestBody: string;
+    params: QP;
+}
+
+export type RouteHandler<QP = any, T = any> = (
+    db: Database,
+    request: Request<QP>
+) => T;
+
+type ResponseCode = number | string;
+type Shorthand =
+    | Registry.ModelNames
+    | Registry.CollectionNames
+    | Array<Registry.ModelNames | Registry.CollectionNames>;
+
+export interface Server {
+    /** Set the base namespace used for all routes defined with get, post, put or del. */
+    namespace: string;
+
+    /**
+     * Generates a single model of type `type`, inserts it into the database
+     * (giving it an id), and returns the data that was added. You can override
+     * the attributes from the factory definition with a hash passed in as the
+     * second parameter.
+     */
+    create<N extends Registry.ModelNames>(
+        type: N,
+        attrs?: Partial<Registry.Models[N]>
+    ): Registry.Models[N];
+
+    /**
+     * Creates amount models of type `type`, optionally overriding the attributes
+     * from the factory with attrs.
+     *
+     * Returns the array of records that were added to the database.
+     */
+    createList<N extends Registry.ModelNames>(
+        type: N,
+        count: number,
+        attrs?: Partial<Registry.Models[N]>
+    ): Registry.Models[N][];
+
+    // Route handlers
+    get(route: string): void;
+    get(route: string, object: object, responseCode?: ResponseCode): void;
+    get(route: string, shorthand: Shorthand, responseCode?: ResponseCode): void;
+    get<QP = void, T = void>(
+        route: string,
+        handler: RouteHandler<QP, T>,
+        responseCode?: ResponseCode
+    ): void;
+
+    post(route: string): void;
+    post(route: string, object: object, responseCode?: ResponseCode): void;
+    post(
+        route: string,
+        shorthand: Shorthand,
+        responseCode?: ResponseCode
+    ): void;
+    post<QP = void, T = void>(
+        route: string,
+        handler: RouteHandler<QP, T>,
+        responseCode?: ResponseCode
+    ): void;
+
+    put(route: string): void;
+    put(route: string, object: object, responseCode?: ResponseCode): void;
+    put(route: string, shorthand: Shorthand, responseCode?: ResponseCode): void;
+    put<QP = void, T = void>(
+        route: string,
+        handler: RouteHandler<QP, T>,
+        responseCode?: ResponseCode
+    ): void;
+
+    del(route: string): void;
+    del(route: string, object: object, responseCode?: ResponseCode): void;
+    del(route: string, shorthand: Shorthand, responseCode?: ResponseCode): void;
+    del<QP = void, T = void>(
+        route: string,
+        handler: RouteHandler<QP, T>,
+        responseCode?: ResponseCode
+    ): void;
+
+    /**
+     * By default, all the data files under `/fixtures` will be loaded during
+     * testing if you don’t have factories defined, and during development if you
+     * don’t have `/scenarios/default.js` defined. You can use `loadFixtures()` to
+     * also load fixture files in either of these environments, in addition to
+     * using factories to seed your database.
+     *
+     * `server.loadFixtures()` loads all the files, and
+     * `server.loadFixtures(file1, file2...)` loads selective fixture files.
+     *
+     * For example, in a test you may want to start out with all your fixture data
+     * loaded, or in development, you may want to load a few reference fixture
+     * files, and use factories to define the rest of your data.
+     */
+    loadFixtures(): void;
+    loadFixtures(...files: string[]): void;
+
+    /**
+     * By default, if your Ember app makes a request that is not defined in your
+     * server config, Mirage will throw an error. You can use passthrough to
+     * whitelist requests, and allow them to pass through your Mirage server to
+     * the actual network layer.
+     *
+     * _**Tip:** Put all passthrough config at the bottom of your `config.js`
+     * file, to give your route handlers precedence._
+     *
+     * You can also pass a list of paths, or call `passthrough` multiple times.
+     *
+     * If you want only certain verbs to pass through, pass an array as the last
+     * argument with the specified verbs.
+     *
+     * If you want all requests on the current domain to pass through, simply
+     * invoke the method with no arguments. Note again that the current namespace
+     * (i.e. any `namespace` property defined above this call) will be applied.
+     *
+     * You can also allow other-origin hosts to passthrough. If you use a
+     * fully-qualified domain name, the `namespace` property will be ignored.
+     * Use two * wildcards to match all requests under a path.
+     *
+     * Be aware that currently, passthrough only works with jQuery >= 2.x. See [this issue] for details.
+     *
+     * [this issue]: https://github.com/pretenderjs/pretender/issues/85
+     */
+    passthrough(): void;
+    passthrough(route: string, methods?: string[]): void;
+    passthrough(route: string, route1: string, methods?: string[]): void;
+    passthrough(
+        route: string,
+        route1: string,
+        route2: string,
+        methods?: string[]
+    ): void;
+    passthrough(
+        route: string,
+        route1: string,
+        route2: string,
+        route3: string,
+        methods?: string[]
+    ): void;
+    passthrough(
+        route: string,
+        route1: string,
+        route2: string,
+        route3: string,
+        route4: string,
+        methods?: string[]
+    ): void;
+    passthrough(
+        route: string,
+        route1: string,
+        route2: string,
+        route3: string,
+        route4: string,
+        route5: string,
+        methods?: string[]
+    ): void;
+    passthrough(route: string, ...moreRoutes: string[]): void;
+
+    shutdown(): void;
+
+    /**
+     * Mirage uses [pretender.js] as its xhttp interceptor. In your Mirage config,
+     * `this.pretender` refers to the actual pretender instance, so any config
+     * options that work there will work here as well. By default, content
+     * returned is json stringified, so you can just return js objects.
+     *
+     * [pretender.js]: https://github.com/trek/pretender
+     *
+     * Refer to [pretender’s docs] if you want to change this or any other options
+     * on your pretender instance.
+     *
+     * [pretender's docs]: https://github.com/trek/pretender#mutating-the-body
+     */
+    pretender: any;
+
+    /**
+     * If your entire Ember app uses an external (other-origin) API, you can
+     * globally configure the domain via `urlPrefix`.
+     */
+    urlPrefix: string;
+
+    db: Database;
+}
+
+declare global {
+    export const server: Server;
+}
+
+declare namespace Mirage {
+    const Response: MirageResponse;
+    const Factory: MirageFactory;
+}
+
+export namespace faker {
+    const address: {
+        city(): string;
+        countryCode(): string;
+        latitude(): string;
+        longitude(): string;
+        state(): string;
+        streetAddress(): string;
+        zipCode(): string;
+    };
+
+    const commerce: {
+        price(): number;
+        product(): string;
+        productName(): string;
+        productAdjective(): string;
+        productMaterial(): string;
+    };
+
+    const hacker: {
+        noun(): string;
+    };
+
+    const internet: {
+        email(): string;
+        password(): string;
+    };
+
+    const lorem: {
+        sentence(): string;
+    };
+
+    const name: {
+        firstName(): string;
+        lastName(): string;
+    };
+
+    const phone: {
+        phoneNumber(): string;
+    };
+
+    const random: {
+        number(): number;
+    };
+}
+
+export default Mirage;

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/ololabs/mobile-web-client
 
 import Ember from 'ember';
-import * as Registry from './registry';
+import { ModelRegistry, ModelNames, ModelNamesPlural, DbCollections, SchemaCollections } from './registry';
 import fakerStatic = require('faker');
 
 type EmberObject = Ember.Object;
@@ -18,8 +18,18 @@ interface MirageFactory extends EmberObject {}
 export const Response: MirageResponse;
 export const Factory: MirageFactory;
 
-export interface Schema {
+export interface Schema extends SchemaCollections {
     db: Database;
+    registerModels(hash: any): any;
+    registerModel(type: any, ModelClass: any): any;
+    modelFor(type: any): any;
+    new(type: any, attrs: any): any;
+    create(type: any, attrs: any): any;
+    all(type: any): any;
+    find(type: any, ids: any): any;
+    findBy(type: any, attributeName: any): any;
+    where(type: any, query: any): any;
+    first(type: any): any;
 }
 
 /**
@@ -27,8 +37,14 @@ export interface Schema {
  * handlers. You retrieve or modify data from the database, then return what you
  * want for that route.
  */
-export interface Database extends Registry.Collections {
-    createCollection(name: string): void;
+export interface Database extends DbCollections {
+    loadData(data: any): any;
+    dump(): any;
+    createCollection(name: any, initialData: any): any;
+    createCollections(collections: any): any;
+    emptyData(): any;
+    identityManagerFor(name: any): any;
+    registerIdentityManagers(): any;
 }
 
 /**
@@ -42,9 +58,9 @@ export interface FakeRequest<QP> extends XMLHttpRequest {
 
 type ResponseCode = number | string;
 type Shorthand =
-    | Registry.ModelNames
-    | Registry.CollectionNames
-    | Array<Registry.ModelNames | Registry.CollectionNames>;
+    | ModelNames
+    | ModelNamesPlural
+    | Array<ModelNames | ModelNamesPlural>;
 
 interface FunctionRouteHandler<QP> {
     request: FakeRequest<QP>;
@@ -93,10 +109,10 @@ export interface Server {
      * the attributes from the factory definition with a hash passed in as the
      * second parameter.
      */
-    create<N extends Registry.ModelNames>(
+    create<N extends ModelNames>(
         type: N,
-        attrs?: Partial<Registry.Models[N]>
-    ): Registry.Models[N];
+        attrs?: Partial<ModelRegistry[N]>
+    ): ModelRegistry[N];
 
     /**
      * Creates amount models of type `type`, optionally overriding the attributes
@@ -104,11 +120,11 @@ export interface Server {
      *
      * Returns the array of records that were added to the database.
      */
-    createList<N extends Registry.ModelNames>(
+    createList<N extends ModelNames>(
         type: N,
         count: number,
-        attrs?: Partial<Registry.Models[N]>
-    ): Registry.Models[N][];
+        attrs?: Partial<ModelRegistry[N]>
+    ): Array<ModelRegistry[N]>;
 
     get: RouteHandler;
     post: RouteHandler;

--- a/types/ember-cli-mirage/registry.d.ts
+++ b/types/ember-cli-mirage/registry.d.ts
@@ -1,13 +1,22 @@
-import Collection from './collection';
+import { DbCollection, SchemaCollection } from './collection';
 
-export interface Models {
+export interface ModelRegistry {
     // string -> Model
+    // e.g. 'blog-post': typeof BlogPost
 }
 
-export type ModelNames = keyof Models;
-
-export interface Collections {
-    // string -> Collection<Model>
+export interface ModelRegistryPlural {
+    // string -> Model
+    // e.g. blogPosts: typeof BlogPost
 }
 
-export type CollectionNames = keyof Collections;
+export type ModelNames = keyof ModelRegistry;
+export type ModelNamesPlural = keyof ModelRegistryPlural;
+
+export type DbCollections = {
+    [P in keyof ModelRegistryPlural]: DbCollection<ModelRegistryPlural[P]>
+};
+
+export type SchemaCollections = {
+    [P in keyof ModelRegistryPlural]: SchemaCollection<ModelRegistryPlural[P]>
+};

--- a/types/ember-cli-mirage/registry.d.ts
+++ b/types/ember-cli-mirage/registry.d.ts
@@ -1,0 +1,13 @@
+import Collection from './collection';
+
+export interface Models {
+    // string -> Model
+}
+
+export type ModelNames = keyof Models;
+
+export interface Collections {
+    // string -> Collection<Model>
+}
+
+export type CollectionNames = keyof Collections;

--- a/types/ember-cli-mirage/test/config.ts
+++ b/types/ember-cli-mirage/test/config.ts
@@ -1,0 +1,99 @@
+import { Server } from "ember-cli-mirage";
+
+export default function(this: Server) {
+    this.namespace = 'api';
+
+    this.timing = 400; // default
+
+    this.passthrough();
+    this.passthrough('/addresses', '/contacts');
+    this.passthrough('/something');
+
+    this.pretender.handledRequest = function(verb, path, request) {
+        let { responseText } = request;
+        // log request and response data
+    }
+
+    this.get('/authors', () => {
+        return {
+            authors: [
+                {id: 1, name: 'Zelda'},
+                {id: 2, name: 'Link'},
+                {id: 3, name: 'Epona'},
+            ]
+        };
+    });
+
+    this.get('/authors');
+    this.get('/authors/:id');
+    this.get('/posts/:id', 'blog-posts');
+    this.post('/authors');
+    this.put('/authors/:id');
+    this.patch('/authors/:id');
+    this.del('/authors/:id');
+    this.get('/contacts', { coalesce: true });
+    this.post('/contacts', 'user');  // optionally specify the type as second param
+    this.get('/contacts', 'users', { coalesce: true });
+    this.del('/contacts/:id', ['contact', 'addresses']);
+
+    this.resource('contacts', { only: ['index', 'show'] });
+    this.resource('contacts', { except: ['update'] });
+    this.resource('blog-posts', { path: '/posts' });
+
+    this.get('/authors', () => {
+        return ['Link', 'Zelda', 'Epona'];
+    });
+
+    this.get('/authors', (schema, request) => {
+        return schema.authors.all();
+    });
+
+    this.post('/authors', (schema, request) => {
+        const attrs = JSON.parse(request.requestBody).author;
+        return schema.authors.create(attrs);
+    });
+
+    this.get('/authors/:id/blog-posts', (schema, request) => {
+        let author = schema.authors.find(request.params.id);
+        return author.blogPosts;
+    });
+
+    this.del('/authors/:id', (schema, request) => {
+        let author = schema.authors.find(request.params.id);
+        author.posts.delete();
+        author.delete();
+    });
+
+    this.post('/authors', function(schema, request) {
+        let attrs = JSON.parse(request.requestBody).author;
+
+        if (attrs.name) {
+            return schema.authors.create(attrs);
+        } else {
+            return new Response(400, {some: 'header'}, {errors: ['name cannot be blank']});
+        }
+    });
+
+    this.put('/contacts/:id', function({ contacts }, request) {
+        let id = request.params.id;
+        let attrs = this.normalizedRequestAttrs();
+
+        return contacts.find(id).update(attrs);
+    });
+
+    this.del('/contacts/:id', ({ contacts }, request) => {
+        let id = request.params.id;
+        let contact = contacts.find(id);
+
+        contact.addresses.destroy();
+        contact.destroy();
+    });
+
+    this.get('/complex_query', () => {
+        return [1, 2, 3, 4, 5];
+    }, { timing: 3000 });
+}
+
+export function testConfig() {
+    // test-only config, does not apply to development
+}

--- a/types/ember-cli-mirage/test/factory.ts
+++ b/types/ember-cli-mirage/test/factory.ts
@@ -20,8 +20,11 @@ const AuthorFactory = Factory.extend({
     },
     age() {
         // list method added by Mirage
-        return faker.list.random(18, 20, 28, 32, 45, 60)();
-    },
+        let random: number = faker.list.random(18, 20, 28, 32, 45, 60)();
+        let num: number = faker.random.number();
+        let range: number = faker.random.number.range(20, 30)();
+        return range;
+    }
 });
 
 // mirage/factories/contact.js

--- a/types/ember-cli-mirage/test/factory.ts
+++ b/types/ember-cli-mirage/test/factory.ts
@@ -1,0 +1,67 @@
+import { Factory, faker, association, trait } from 'ember-cli-mirage';
+
+const PersonFactory = Factory.extend({
+    name(i) {
+        return `Person ${i}`;
+    },
+    age: 28,
+    admin: false,
+    avatar() {
+        return faker.internet.avatar();
+    }
+});
+
+const AuthorFactory = Factory.extend({
+    firstName() {
+        return faker.name.firstName();
+    },
+    lastName() {
+        return faker.name.lastName();
+    },
+    age() {
+        // list method added by Mirage
+        return faker.list.random(18, 20, 28, 32, 45, 60)();
+    },
+});
+
+// mirage/factories/contact.js
+const ContactFactory = Factory.extend({
+
+    isAdmin: faker.random.boolean,
+
+    afterCreate(contact, server) {
+        // Only allow a max of 5 admins to be created
+        if (server.schema.contacts.where({ isAdmin: true }).models.length >= 5) {
+            contact.update({ isAdmin: false });
+        }
+    }
+
+});
+
+// mirage/factories/article.js
+const ArticleFactory = Factory.extend({
+    title: 'ember-cli-mirage rockzzz',
+    author: association()
+});
+
+// mirage/factories/author.js
+const AuthorFactory2 = Factory.extend({
+    withNames: trait({
+        firstName: 'Yehuda',
+        lastName: 'Katz'
+    })
+});
+
+// mirage/factories/author.js
+const AuthorFactory3 = Factory.extend({
+    firstName: faker.name.firstName,
+    afterCreate(author, server) {
+        server.create('post', { author });
+    }
+});
+
+// mirage/factories/subject.js
+const SubjectFactory = Factory.extend({
+    name: faker.list.cycle('Economics', 'Philosophy', 'English', 'History', 'Mathematics'),
+    students: faker.list.random(100, 200, 300, 400, 500)
+});

--- a/types/ember-cli-mirage/test/fixture.ts
+++ b/types/ember-cli-mirage/test/fixture.ts
@@ -1,0 +1,7 @@
+import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
+
+export default [
+    {id: 1, firstName: 'Link'},
+    {id: 2, firstName: 'Zelda'},
+    {id: 3, firstName: 'Epona'}
+];

--- a/types/ember-cli-mirage/test/model.ts
+++ b/types/ember-cli-mirage/test/model.ts
@@ -9,6 +9,19 @@ const Author1 = Model.extend({
 });
 
 // mirage/models/blog-post.js
+type BlogPost = typeof BlogPost.prototype;
 const BlogPost = Model.extend({
     author: belongsTo()
 });
+
+declare module "ember-cli-mirage/registry" {
+    export interface ModelRegistry {
+        'author': typeof Author;
+        'blog-post': typeof BlogPost;
+    }
+
+    export interface ModelRegistryPlural {
+        authors: typeof Author;
+        blogPosts: typeof BlogPost;
+    }
+}

--- a/types/ember-cli-mirage/test/model.ts
+++ b/types/ember-cli-mirage/test/model.ts
@@ -1,0 +1,14 @@
+import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
+
+const Author = Model.extend({
+});
+
+// mirage/models/author.js
+const Author1 = Model.extend({
+    blogPosts: hasMany()
+});
+
+// mirage/models/blog-post.js
+const BlogPost = Model.extend({
+    author: belongsTo()
+});

--- a/types/ember-cli-mirage/test/scenario.ts
+++ b/types/ember-cli-mirage/test/scenario.ts
@@ -1,0 +1,7 @@
+export default function(server) {
+    server.createList('author', 10);
+    server.createList('blog-post', 10);
+
+    let author = server.create('author', {name: 'Zelda'});
+    server.createList('blog-post', 20, { author });
+};

--- a/types/ember-cli-mirage/test/scenario.ts
+++ b/types/ember-cli-mirage/test/scenario.ts
@@ -1,4 +1,6 @@
-export default function(server) {
+import {Server} from "ember-cli-mirage";
+
+export default function(server: Server) {
     server.createList('author', 10);
     server.createList('blog-post', 10);
 

--- a/types/ember-cli-mirage/test/schema.ts
+++ b/types/ember-cli-mirage/test/schema.ts
@@ -1,0 +1,21 @@
+import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
+
+
+let posts = schema.blogPosts.all();
+posts.modelName; // "blog-post"
+
+let posts2 = schema.blogPosts.find([1, 2, 4]);
+let posts3 = schema.blogPosts.where({published: true});
+
+posts.update('published', true); // the db was updated for all posts
+posts.save(); // all posts saved to db
+posts.reload(); // reloads data for each post from the db
+posts.destroy(); // all posts removed from db
+
+let postsByTitleAsc = posts.sort((a, b) => {
+    return b.title < a.title;
+});
+
+let longPosts = posts.filter((postModel) => {
+    return postModel.wordCount >= 1000;
+});

--- a/types/ember-cli-mirage/test/schema.ts
+++ b/types/ember-cli-mirage/test/schema.ts
@@ -1,4 +1,4 @@
-import {Model, hasMany, belongsTo, Schema} from 'ember-cli-mirage';
+import { Schema } from 'ember-cli-mirage';
 
 declare const schema: Schema;
 
@@ -16,7 +16,9 @@ posts.reload(); // reloads data for each post from the db
 posts.destroy(); // all posts removed from db
 
 let postsByTitleAsc = posts.sort((a, b) => {
-    return b.title < a.title;
+    if (b.title === a.title) return 0;
+    if (b.title < a.title) return -1;
+    return 1;
 });
 
 let longPosts = posts.filter((postModel) => {

--- a/types/ember-cli-mirage/test/schema.ts
+++ b/types/ember-cli-mirage/test/schema.ts
@@ -7,6 +7,8 @@ posts.modelName; // "blog-post"
 
 let posts2 = schema.blogPosts.find([1, 2, 4]);
 let posts3 = schema.blogPosts.where({published: true});
+let post = schema.blogPosts.findBy({ 'author': 'Link' });
+let post2 = schema.blogPosts.find(1);
 
 posts.update('published', true); // the db was updated for all posts
 posts.save(); // all posts saved to db

--- a/types/ember-cli-mirage/test/schema.ts
+++ b/types/ember-cli-mirage/test/schema.ts
@@ -1,5 +1,6 @@
-import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
+import {Model, hasMany, belongsTo, Schema} from 'ember-cli-mirage';
 
+declare const schema: Schema;
 
 let posts = schema.blogPosts.all();
 posts.modelName; // "blog-post"

--- a/types/ember-cli-mirage/test/serializer.ts
+++ b/types/ember-cli-mirage/test/serializer.ts
@@ -1,0 +1,19 @@
+import { Serializer } from 'ember-cli-mirage';
+import Ember from 'ember';
+const { dasherize } = Ember.String;
+
+// mirage/serializers/application.js
+const ApplicationSerializer = Serializer.extend({
+    keyForAttribute(attr) {
+        return dasherize(attr);
+    },
+
+    keyForRelationship(attr) {
+        return dasherize(attr);
+    },
+});
+
+// mirage/serializers/author.js
+const AuthorSerializer = Serializer.extend({
+    include: ['blogPosts']
+});

--- a/types/ember-cli-mirage/test/server.ts
+++ b/types/ember-cli-mirage/test/server.ts
@@ -1,0 +1,22 @@
+import { startMirage } from 'yourapp/initializers/ember-cli-mirage';
+
+let server2 = startMirage();
+server2.shutdown();
+
+server.create('lesson', {title: 'My First Lesson'});
+
+server.put('/lessons/:id', (schema, request) => {
+    let params = JSON.parse(request.requestBody);
+});
+server.post('/questions', {errors: ['There was an error']}, 500);
+
+server.loadFixtures();
+server.loadFixtures('countries', 'states');
+
+server.create('user');
+let authors = server.createList('author', 3);
+let author = server.create('author', { admin: true });
+let author2 = server.create('author', { admin: true, age: 30 });
+server.createList('post', 10, { author });
+
+server.logging = true;

--- a/types/ember-cli-mirage/test/server.ts
+++ b/types/ember-cli-mirage/test/server.ts
@@ -3,8 +3,6 @@ import { startMirage } from 'yourapp/initializers/ember-cli-mirage';
 let server2 = startMirage();
 server2.shutdown();
 
-server.create('lesson', {title: 'My First Lesson'});
-
 server.put('/lessons/:id', (schema, request) => {
     let params = JSON.parse(request.requestBody);
 });
@@ -13,10 +11,10 @@ server.post('/questions', {errors: ['There was an error']}, 500);
 server.loadFixtures();
 server.loadFixtures('countries', 'states');
 
-server.create('user');
+server.create('author');
 let authors = server.createList('author', 3);
 let author = server.create('author', { admin: true });
 let author2 = server.create('author', { admin: true, age: 30 });
-server.createList('post', 10, { author });
+server.createList('blog-post', 10, { author });
 
 server.logging = true;

--- a/types/ember-cli-mirage/tsconfig.json
+++ b/types/ember-cli-mirage/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es6"],
+        "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,

--- a/types/ember-cli-mirage/tsconfig.json
+++ b/types/ember-cli-mirage/tsconfig.json
@@ -11,5 +11,14 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": ["index.d.ts", "ember-cli-qunit-tests.ts"]
+    "files": [
+        "index.d.ts",
+        "test/config.ts",
+        "test/factory.ts",
+        "test/fixture.ts",
+        "test/model.ts",
+        "test/scenario.ts",
+        "test/serializer.ts",
+        "test/server.ts"
+    ]
 }

--- a/types/ember-cli-mirage/tsconfig.json
+++ b/types/ember-cli-mirage/tsconfig.json
@@ -17,6 +17,7 @@
         "test/factory.ts",
         "test/fixture.ts",
         "test/model.ts",
+        "test/schema.ts",
         "test/scenario.ts",
         "test/serializer.ts",
         "test/server.ts"

--- a/types/ember-cli-mirage/tsconfig.json
+++ b/types/ember-cli-mirage/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "ember-cli-qunit-tests.ts"]
+}

--- a/types/ember-cli-mirage/tslint.json
+++ b/types/ember-cli-mirage/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,10 @@
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.0.4.tgz#fe86315d9a66827feeb16f73bc954688ec950e18"
 
+"@types/faker@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-4.1.1.tgz#989666efde54c07b7f960a552b5fceb5d5e570e0"
+
 "@types/handlebars@^4.0.35":
   version "4.0.36"
   resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.36.tgz#ff57c77fa1ab6713bb446534ddc4d979707a3a79"


### PR DESCRIPTION
I'd call this a *decent* (though fairly outdated, and messy in a way I’m not giddy about) stab at doing a type-registry-based approach to Mirage.

However, note that we can *probably* get a lot of mileage out of generating the types for 0.3.x, because it’s pretty well-JSDoc’d, and uses ES6 classes. Bound to be better than what I cobbled together a couple months ago. See e.g. the [`Collection`](https://github.com/samselikoff/ember-cli-mirage/blob/master/addon/orm/collection.js) implementation.

(Really, we just need to get ember-cli-typescript support for add-ons out the door, because this could just be well-typed TS instead of well-doc'd JS.)