### PR TITLE
Addressing typing problem with Route#model

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1855,7 +1855,7 @@ declare module 'ember' {
              * A hook you can implement to convert the URL into the model for
              * this route.
              */
-            model<T>(params: {}, transition: Transition): T | Rsvp.Promise<T>;
+            model(params: {}, transition: Transition): any;
 
             /**
              * Returns the model of a parent (or any ancestor) route


### PR DESCRIPTION
I was having a weird problem with a simple route, as follows:

```javascript
import Route from '@ember/routing/route'

export default class Certificate extends Route {

  model () {
    return this.store.findAll('certificate')
  }
}
```

From this, TypeScript was generating errors:
```app/routes/index/certificates.ts(3,22): error TS2415: Class 'Certificate' incorrectly extends base class 'Route'.
  Types of property 'model' are incompatible.
    Type '() => PromiseArray<Model>' is not assignable to type '<T>(params: {}, transition: Transition) => T | Promise<T>'.
      Type 'PromiseArray<Model>' is not assignable to type 'T | Promise<T>'.
        Type 'PromiseArray<Model>' is not assignable to type 'Promise<T>'.
          Types of property 'then' are incompatible.
            Type '<TResult1 = PromiseArray<Model>, TResult2 = never>(onFulfilled?: (value: PromiseArray<Model>) => ...' is not assignable to type '<TResult1 = T, TResult2 = never>(onFulfilled?: (value: T) => TResult1 | PromiseLike<TResult1>, on...'.
              Types of parameters 'onFulfilled' and 'onFulfilled' are incompatible.
                Types of parameters 'value' and 'value' are incompatible.
                  Type 'PromiseArray<Model>' is not assignable to type 'T'.
```

After a conversation with @dwickern 
(https://embercommunity.slack.com/archives/C2F8Q3SK1/p1508779680000658),
implementing a small change to typing.