### PR TITLE
Add ajax and ajaxOptions to RESTAdapter

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -1033,6 +1033,14 @@ declare namespace DS {
    */
   class RESTAdapter extends Adapter implements BuildURLMixin {
     /**
+     * Takes a URL, an HTTP method and a hash of data, and makes an HTTP request.
+     */
+    ajax(url: string, type: string, options: object): Promise<any>;
+    /**
+     * Generate ajax options
+     */
+    ajaxOptions(url: string, type: string, options: object): object;
+    /**
      * By default, the RESTAdapter will send the query params sorted alphabetically to the
      * server.
      */

--- a/types/ember-data/test/adapter.ts
+++ b/types/ember-data/test/adapter.ts
@@ -23,3 +23,12 @@ const AuthTokenHeader = DS.JSONAPIAdapter.extend({
         };
     })
 });
+
+const OverrideQuery = DS.JSONAPIAdapter.extend({
+    query(store: DS.Store, type: string, query: object) {
+        const url = 'https://api.example.com/my-api';
+        return this.ajax(url, 'POST', {
+            param: 'foo'
+        });
+    }
+});


### PR DESCRIPTION
Sometimes we do need to override the `query`/`findAll` those methods in adapters, then `this.ajax` will be used.
Adding this two private methods so it won't throw error.