### PR TITLE
refactor ember-mocha typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@types/handlebars": "^4.0.35",
     "@types/jquery": "^3.2.11",
+    "@types/mocha": "^2.2.44",
     "@types/qunit": "^2.0.31",
     "jslint": "^0.10.3"
   }

--- a/types/ember-mocha/index.d.ts
+++ b/types/ember-mocha/index.d.ts
@@ -4,16 +4,26 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-declare module 'ember-mocha' {
-    import Ember from 'ember';
-    import { it as mochaIt, SuiteCallbackContext } from 'mocha';
-    import { ModuleCallbacks } from "ember-test-helpers";
+import { TestContext, ModuleCallbacks } from "ember-test-helpers";
+import Ember from 'ember';
+import { it as mochaIt, ISuiteCallbackContext } from 'mocha';
 
+// these globals are re-exported as named exports by ember-mocha
+type mochaBefore = typeof before;
+type mochaAfter = typeof after;
+type mochaBeforeEach = typeof beforeEach;
+type mochaAfterEach = typeof afterEach;
+type mochaSetup = typeof setup;
+type mochaTeardown = typeof teardown;
+type mochaSuiteSetup = typeof suiteSetup;
+type mochaSuiteTeardown = typeof suiteTeardown;
+
+declare module 'ember-mocha' {
     interface ContextDefinitionFunction {
-        (name: string, description: string, callbacks: ModuleCallbacks, tests: (this: SuiteCallbackContext) => void): void;
-        (name: string, description: string, tests: (this: SuiteCallbackContext) => void): void;
-        (name: string, callbacks: ModuleCallbacks, tests: (this: SuiteCallbackContext) => void): void;
-        (name: string, tests: (this: SuiteCallbackContext) => void): void;
+        (name: string, description: string, callbacks: ModuleCallbacks, tests: (this: ISuiteCallbackContext) => void): void;
+        (name: string, description: string, tests: (this: ISuiteCallbackContext) => void): void;
+        (name: string, callbacks: ModuleCallbacks, tests: (this: ISuiteCallbackContext) => void): void;
+        (name: string, tests: (this: ISuiteCallbackContext) => void): void;
     }
 
     interface ContextDefinition extends ContextDefinitionFunction {
@@ -67,73 +77,19 @@ declare module 'ember-mocha' {
 }
 
 declare module 'mocha' {
-    import { TestContext } from "ember-test-helpers";
+    // augment test callback context
+    interface ITestCallbackContext extends TestContext {}
+    interface IHookCallbackContext extends TestContext {}
 
-    interface Runnable {
-        title: string;
-        fn(...args: any[]): any;
-        async: boolean;
-        sync: boolean;
-        timedOut: boolean;
-        timeout(n: number): this;
-    }
-
-    interface Suite {
-        parent: Suite;
-        title: string;
-
-        fullTitle(): string;
-    }
-
-    interface Test extends Runnable {
-        parent: Suite;
-        pending: boolean;
-        state: 'failed' | 'passed' | undefined;
-
-        fullTitle(): string;
-    }
-
-    interface MochaTestContext extends TestContext {
-        skip(): this;
-        timeout(ms: number): this;
-    }
-
-    interface BeforeAndAfterContext extends MochaTestContext {
-        currentTest: Test;
-    }
-
-    interface TestDefinition {
-        (expectation: string, callback?: (this: MochaTestContext, done: MochaDone) => any): Test;
-        only(expectation: string, callback?: (this: MochaTestContext, done: MochaDone) => any): Test;
-        skip(expectation: string, callback?: (this: MochaTestContext, done: MochaDone) => any): void;
-        timeout(ms: number): void;
-        state: "failed" | "passed";
-    }
-
-    type MochaDone = (error?: any) => any;
-
-    interface SuiteCallbackContext {
-        timeout(ms: number): this;
-        retries(n: number): this;
-        slow(ms: number): this;
-    }
-
-    interface ContextDefinition {
-        (description: string, callback: (this: SuiteCallbackContext) => void): Suite;
-        only(description: string, callback: (this: SuiteCallbackContext) => void): Suite;
-        skip(description: string, callback: (this: SuiteCallbackContext) => void): void;
-    }
-
-    // export const mocha: Mocha;
-    export const describe: ContextDefinition;
-    export const context: ContextDefinition;
-    export const it: TestDefinition;
-    export function before(callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
-    export function before(description: string, callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
-    export function after(callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
-    export function after(description: string, callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
-    export function beforeEach(callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
-    export function beforeEach(description: string, callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
-    export function afterEach(callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
-    export function afterEach(description: string, callback: (this: BeforeAndAfterContext, done: MochaDone) => any): void;
+    // re-export mocha globals as named exports
+    export const describe: Mocha.IContextDefinition;
+    export const it: Mocha.ITestDefinition;
+    export const setup: mochaSetup;
+    export const teardown: mochaTeardown;
+    export const suiteSetup: mochaSuiteSetup;
+    export const suiteTeardown: mochaSuiteTeardown;
+    export const before: mochaBefore;
+    export const after: mochaAfter;
+    export const beforeEach: mochaBeforeEach;
+    export const afterEach: mochaAfterEach;
 }

--- a/types/ember-mocha/tslint.json
+++ b/types/ember-mocha/tslint.json
@@ -5,6 +5,14 @@
         "strict-export-declare-modifiers": false,
         "no-duplicate-imports": false,
         "unified-signatures": false,
-        "no-declare-current-package": false
+        "no-declare-current-package": false,
+
+        // ERROR: An interface declaring no members is equivalent to its supertype.
+        // -- Not true when augmenting an interface
+        "no-empty-interface": false,
+
+        // ERROR: interface name must not have an "I" prefix
+        // -- Augmenting @types/mocha which uses "I" prefix
+        "interface-name": false
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,10 @@
   version "3.2.15"
   resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.2.15.tgz#3f620a9f5a0b296866f4bc729825226d0a35fba6"
 
+"@types/mocha@^2.2.44":
+  version "2.2.44"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.44.tgz#1d4a798e53f35212fd5ad4d04050620171cd5b5e"
+
 "@types/parsimmon@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@types/parsimmon/-/parsimmon-1.3.0.tgz#0509b11d85e7d10f83141e5d4490ba8ad5e5cbec"
@@ -555,7 +559,7 @@ debug@2, debug@^2.4.1:
   dependencies:
     ms "2.0.0"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -1090,7 +1094,7 @@ import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -1384,10 +1388,6 @@ lockfile@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.3.tgz#2638fc39a0331e9cac1a04b71799931c9c50df79"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -1395,27 +1395,9 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -1428,10 +1410,6 @@ lodash.assign@^4.0.3, lodash.assign@^4.0.6:
 lodash.clonedeep@~4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
 lodash.union@~4.6.0:
   version "4.6.0"
@@ -2284,7 +2262,7 @@ readable-stream@~2.1.2:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:
@@ -2884,7 +2862,7 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1:
+validate-npm-package-license@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
   dependencies:


### PR DESCRIPTION
Previously the typings were mostly copied from `@types/mocha` because I couldn't figure out how to augment mocha's style of typings